### PR TITLE
[FEAT] 구글 로그인 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '3.5.4'
+	id 'org.springframework.boot' version '3.1.4'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -30,6 +30,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	implementation 'com.google.api-client:google-api-client:1.33.2'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 	compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/com/teamalgo/algo/auth/controller/AuthController.java
+++ b/src/main/java/com/teamalgo/algo/auth/controller/AuthController.java
@@ -1,0 +1,40 @@
+package com.teamalgo.algo.auth.controller;
+
+import com.teamalgo.algo.auth.dto.LoginRequest;
+import com.teamalgo.algo.auth.dto.TokenResponse;
+import com.teamalgo.algo.auth.service.GoogleOAuthService;
+import com.teamalgo.algo.global.common.api.ApiResponse;
+import com.teamalgo.algo.global.common.code.SuccessCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/auth")
+public class AuthController {
+
+    private final GoogleOAuthService googleService;
+
+    // 구글 로그인
+    @PostMapping("/google-login")
+    public ResponseEntity<ApiResponse<TokenResponse>> googleLogin(@RequestBody LoginRequest loginRequest) {
+        TokenResponse response = googleService.authenticateUser(loginRequest.getToken());
+        return ApiResponse.success(SuccessCode._OK, response);
+    }
+
+    // 카카오 로그인
+    @PostMapping("/kakao-login")
+    public ResponseEntity<ApiResponse<TokenResponse>> kakaoLogin(@RequestBody LoginRequest loginRequest) {
+
+        return ApiResponse.success(SuccessCode._OK, null);
+    }
+
+    // 깃허브 로그인
+    @PostMapping("/github-login")
+    public ResponseEntity<ApiResponse<TokenResponse>> githubLogin(@RequestBody LoginRequest loginRequest) {
+
+        return ApiResponse.success(SuccessCode._OK, null);
+    }
+
+}

--- a/src/main/java/com/teamalgo/algo/auth/dto/LoginRequest.java
+++ b/src/main/java/com/teamalgo/algo/auth/dto/LoginRequest.java
@@ -1,0 +1,14 @@
+package com.teamalgo.algo.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class LoginRequest {
+    private String token;
+}

--- a/src/main/java/com/teamalgo/algo/auth/dto/TokenResponse.java
+++ b/src/main/java/com/teamalgo/algo/auth/dto/TokenResponse.java
@@ -1,0 +1,17 @@
+package com.teamalgo.algo.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class TokenResponse {
+
+    private String accessToken;
+    private String refreshToken;
+
+}

--- a/src/main/java/com/teamalgo/algo/auth/security/GoogleTokenVerifier.java
+++ b/src/main/java/com/teamalgo/algo/auth/security/GoogleTokenVerifier.java
@@ -1,0 +1,39 @@
+package com.teamalgo.algo.auth.security;
+
+import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken;
+import com.google.api.client.googleapis.auth.oauth2.GoogleIdTokenVerifier;
+import com.google.api.client.http.javanet.NetHttpTransport;
+import com.google.api.client.json.JsonFactory;
+import com.google.api.client.json.gson.GsonFactory;
+
+import com.teamalgo.algo.global.common.code.ErrorCode;
+import com.teamalgo.algo.global.exception.CustomException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.util.Collections;
+
+@Component
+public class GoogleTokenVerifier {
+
+    @Value("${GOOGLE_CLIENT_ID}")
+    private String GOOGLE_CLIENT_ID;
+
+    public GoogleIdToken.Payload verifyToken(String token) {
+
+        try {
+            JsonFactory jsonFactory = GsonFactory.getDefaultInstance();
+
+            GoogleIdTokenVerifier verifier = new GoogleIdTokenVerifier.Builder(
+                    new NetHttpTransport(), jsonFactory)
+                    .setAudience(Collections.singletonList(GOOGLE_CLIENT_ID))
+                    .build();
+
+            GoogleIdToken googleIdToken = verifier.verify(token);
+            return (googleIdToken != null) ? googleIdToken.getPayload() : null;
+
+        } catch (Exception e) {
+            throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR);
+        }
+    }
+}

--- a/src/main/java/com/teamalgo/algo/user/domain/User.java
+++ b/src/main/java/com/teamalgo/algo/user/domain/User.java
@@ -17,9 +17,6 @@ public class User {
     @Column(nullable = false, length = 50)
     private String nickname;
 
-    @Column(unique = true, length = 100)
-    private String email;
-
     @Column(nullable = false, length = 20)
     private String provider;  // google, kakao, github
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,14 @@
 spring:
   application:
     name: algo
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            client-id: ${GOOGLE_CLIENT_ID}
+            client-secret: ${GOOGLE_CLIENT_PW}
+            scope: email, profile
 
   config:
     import: optional:file:.env[.properties]


### PR DESCRIPTION
## 💻 작업 내용  
<!-- 이번 PR에서 작업한 내용을 간단하게 적어주세요 -->
- 구글 로그인 API(`/api/auth/google-login`) 구현
- 구글에서 받은 ID 토큰 검증 및 사용자 인증 처리
- 로그인 관련 DTO, 서비스, 컨트롤러 구현

## 📌 변경 사항  
<!-- 코드 변경, 기능 추가/수정, 버그 수정 등 주요 변경 사항을 기술해주세요 -->
- [x] LoginRequest, TokenResponse DTO 추가
- [x] Google OAuth 인증 서비스 구현
- [x] AuthController에 구글 로그인 API 추가

## 🔗 관련 이슈  
<!-- 연결된 이슈 번호를 적어주세요 (ex. #123) -->
#1 (구글 로그인)

## 📝 기타  
<!-- 특이사항, 참고할 점, 리뷰어에게 전달할 내용 등이 있다면 작성해주세요 -->
