### PR TITLE
[FEAT] 깃허브 로그인 API 구현

### DIFF
--- a/src/main/java/com/teamalgo/algo/auth/controller/AuthController.java
+++ b/src/main/java/com/teamalgo/algo/auth/controller/AuthController.java
@@ -2,6 +2,7 @@ package com.teamalgo.algo.auth.controller;
 
 import com.teamalgo.algo.auth.dto.LoginRequest;
 import com.teamalgo.algo.auth.dto.TokenResponse;
+import com.teamalgo.algo.auth.service.GithubOAuthService;
 import com.teamalgo.algo.auth.service.GoogleOAuthService;
 import com.teamalgo.algo.global.common.api.ApiResponse;
 import com.teamalgo.algo.global.common.code.SuccessCode;
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.*;
 public class AuthController {
 
     private final GoogleOAuthService googleService;
+    private final GithubOAuthService githubOAuthService;
 
     // 구글 로그인
     @PostMapping("/google-login")
@@ -33,8 +35,8 @@ public class AuthController {
     // 깃허브 로그인
     @PostMapping("/github-login")
     public ResponseEntity<ApiResponse<TokenResponse>> githubLogin(@RequestBody LoginRequest loginRequest) {
-
-        return ApiResponse.success(SuccessCode._OK, null);
+        TokenResponse response = githubOAuthService.authenticateUser(loginRequest.getToken());
+        return ApiResponse.success(SuccessCode._OK, response);
     }
 
 }

--- a/src/main/java/com/teamalgo/algo/auth/service/GithubOAuthService.java
+++ b/src/main/java/com/teamalgo/algo/auth/service/GithubOAuthService.java
@@ -1,0 +1,101 @@
+package com.teamalgo.algo.auth.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.teamalgo.algo.auth.dto.TokenResponse;
+import com.teamalgo.algo.auth.security.JwtTokenProvider;
+import com.teamalgo.algo.global.common.code.ErrorCode;
+import com.teamalgo.algo.global.exception.CustomException;
+import com.teamalgo.algo.user.domain.User;
+import com.teamalgo.algo.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class GithubOAuthService {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final UserService userService;
+
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    @Value("${GITHUB_CLIENT_ID}")
+    private String clientId;
+
+    @Value("${GITHUB_CLIENT_SECRET}")
+    private String clientSecret;
+
+    @Transactional
+    public TokenResponse authenticateUser(String code) {
+        try {
+            // github에 access token 요청
+            RestTemplate restTemplate = new RestTemplate();
+            String tokenUrl = "https://github.com/login/oauth/access_token";
+
+            HttpHeaders tokenHeaders = new HttpHeaders();
+            tokenHeaders.setContentType(MediaType.APPLICATION_JSON);
+            tokenHeaders.setAccept(List.of(MediaType.APPLICATION_JSON));
+
+            Map<String, String> body = Map.of(
+                    "client_id", clientId,
+                    "client_secret", clientSecret,
+                    "code", code
+            );
+
+            HttpEntity<Map<String, String>> tokenRequest = new HttpEntity<>(body, tokenHeaders);
+
+            ResponseEntity<String> tokenResponse = restTemplate.postForEntity(tokenUrl, tokenRequest, String.class);
+
+            Map<String, Object> tokenMap = objectMapper.readValue(tokenResponse.getBody(), Map.class);
+
+            if (!tokenMap.containsKey("access_token")) {
+                throw new CustomException(ErrorCode.GITHUB_OAUTH_FAILED);
+            }
+
+            String accessTokenGithub = (String) tokenMap.get("access_token");
+
+            // access token으로 사용자 정보 요청
+            HttpHeaders userHeaders = new HttpHeaders();
+            userHeaders.setBearerAuth(accessTokenGithub);
+            userHeaders.setAccept(List.of(MediaType.APPLICATION_JSON));
+
+            HttpEntity<Void> userRequest = new HttpEntity<>(userHeaders);
+
+            ResponseEntity<String> userResponse = restTemplate.exchange(
+                    "https://api.github.com/user",
+                    HttpMethod.GET,
+                    userRequest,
+                    String.class
+            );
+
+            Map<String, Object> userMap = objectMapper.readValue(userResponse.getBody(), Map.class);
+
+            String providerId = String.valueOf(userMap.get("id"));
+            String name = (String) userMap.get("login");
+
+            // DB에 사용자 저장 or 기존 사용자 조회
+            User user = userService.findByProviderAndProviderId("github", providerId)
+                    .orElseGet(() -> userService.saveUser(User.builder()
+                            .nickname(name)
+                            .provider("github")
+                            .providerId(providerId)
+                            .build()));
+
+            // JWT 발급
+            String accessToken = jwtTokenProvider.generateAccessToken(String.valueOf(user.getId()));
+            String refreshToken = jwtTokenProvider.generateRefreshToken(String.valueOf(user.getId()));
+
+            return new TokenResponse(accessToken, refreshToken);
+
+        } catch (Exception e) {
+            throw new CustomException(ErrorCode.GITHUB_OAUTH_FAILED);
+        }
+    }
+}

--- a/src/main/java/com/teamalgo/algo/global/common/code/ErrorCode.java
+++ b/src/main/java/com/teamalgo/algo/global/common/code/ErrorCode.java
@@ -10,7 +10,8 @@ public enum ErrorCode implements BaseCode {
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
     INVALID_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류가 발생했습니다."),
-    JWT_TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "토큰이 유효하지 않거나 만료되었습니다.");
+    JWT_TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "토큰이 유효하지 않거나 만료되었습니다."),
+    GITHUB_OAUTH_FAILED(HttpStatus.UNAUTHORIZED, "GitHub OAuth 인증에 실패했습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,14 +1,6 @@
 spring:
   application:
     name: algo
-  security:
-    oauth2:
-      client:
-        registration:
-          google:
-            client-id: ${GOOGLE_CLIENT_ID}
-            client-secret: ${GOOGLE_CLIENT_PW}
-            scope: email, profile
 
   config:
     import: optional:file:.env[.properties]


### PR DESCRIPTION
## 💻 작업 내용  
<!-- 이번 PR에서 작업한 내용을 간단하게 적어주세요 -->
- 깃허브 로그인 API(`/api/auth/github-login`) 구현
- 깃허브에서 받은 authorization code로 access token 발급 & 사용자 정보 조회  

## 📌 변경 사항  
<!-- 코드 변경, 기능 추가/수정, 버그 수정 등 주요 변경 사항을 기술해주세요 -->
- [x] `GithubOAuthService` 구현  
- [x] `GITHUB_OAUTH_FAILED` 에러코드 추가

## 🔗 관련 이슈  
<!-- 연결된 이슈 번호를 적어주세요 (ex. #123) -->
#1 (깃허브 로그인)

## 📝 기타  
<!-- 특이사항, 참고할 점, 리뷰어에게 전달할 내용 등이 있다면 작성해주세요 -->
