### PR TITLE
[FEAT] 사용자 관련 API 구현

### DIFF
--- a/src/main/java/com/teamalgo/algo/controller/UserController.java
+++ b/src/main/java/com/teamalgo/algo/controller/UserController.java
@@ -1,0 +1,28 @@
+package com.teamalgo.algo.controller;
+
+import com.teamalgo.algo.dto.UserResponse;
+import com.teamalgo.algo.global.common.api.ApiResponse;
+import com.teamalgo.algo.global.common.code.SuccessCode;
+import com.teamalgo.algo.service.user.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/users")
+public class UserController {
+
+    private final UserService userService;
+
+    // 사용자 정보 조회
+    @GetMapping("/me")
+    public ResponseEntity<ApiResponse<UserResponse>> getMyInfo(Authentication authentication) {
+        Long userId = Long.parseLong(authentication.getName());
+        UserResponse response = userService.getUserInfo(userId);
+        return ApiResponse.success(SuccessCode._OK, response);
+    }
+}

--- a/src/main/java/com/teamalgo/algo/controller/UserController.java
+++ b/src/main/java/com/teamalgo/algo/controller/UserController.java
@@ -34,4 +34,12 @@ public class UserController {
         UserResponse response = userService.updateUser(userId, request);
         return ApiResponse.success(SuccessCode._OK, response);
     }
+
+    // 사용자 탈퇴
+    @DeleteMapping("/me")
+    public ResponseEntity<ApiResponse<Object>> deleteUser(Authentication authentication) {
+        Long userId = Long.parseLong(authentication.getName());
+        userService.deleteUser(userId);
+        return ApiResponse.success(SuccessCode._NO_CONTENT, null);
+    }
 }

--- a/src/main/java/com/teamalgo/algo/controller/UserController.java
+++ b/src/main/java/com/teamalgo/algo/controller/UserController.java
@@ -1,15 +1,16 @@
 package com.teamalgo.algo.controller;
 
 import com.teamalgo.algo.dto.UserResponse;
+import com.teamalgo.algo.dto.UserUpdateRequest;
 import com.teamalgo.algo.global.common.api.ApiResponse;
 import com.teamalgo.algo.global.common.code.SuccessCode;
 import com.teamalgo.algo.service.user.UserService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -23,6 +24,14 @@ public class UserController {
     public ResponseEntity<ApiResponse<UserResponse>> getMyInfo(Authentication authentication) {
         Long userId = Long.parseLong(authentication.getName());
         UserResponse response = userService.getUserInfo(userId);
+        return ApiResponse.success(SuccessCode._OK, response);
+    }
+
+    // 사용자 정보 수정
+    @PatchMapping("/me")
+    public ResponseEntity<ApiResponse<UserResponse>> updateMyInfo(Authentication authentication, @RequestBody UserUpdateRequest request) {
+        Long userId = Long.parseLong(authentication.getName());
+        UserResponse response = userService.updateUser(userId, request);
         return ApiResponse.success(SuccessCode._OK, response);
     }
 }

--- a/src/main/java/com/teamalgo/algo/domain/user/User.java
+++ b/src/main/java/com/teamalgo/algo/domain/user/User.java
@@ -52,4 +52,8 @@ public class User extends BaseEntity {
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<StatsDaily> stats = new ArrayList<>();
 
+    public void update(String username, String avatarUrl) {
+        if (username != null) this.username = username;
+        if (avatarUrl != null) this.avatarUrl = avatarUrl;
+    }
 }

--- a/src/main/java/com/teamalgo/algo/dto/UserResponse.java
+++ b/src/main/java/com/teamalgo/algo/dto/UserResponse.java
@@ -1,0 +1,24 @@
+package com.teamalgo.algo.dto;
+
+import com.teamalgo.algo.domain.user.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class UserResponse {
+    private Long id;
+    private String username;
+    private String avatarUrl;
+
+    public static UserResponse from(User user) {
+        return UserResponse.builder()
+                .id(user.getId())
+                .username(user.getUsername())
+                .avatarUrl(user.getAvatarUrl())
+                .build();
+    }
+
+}

--- a/src/main/java/com/teamalgo/algo/dto/UserUpdateRequest.java
+++ b/src/main/java/com/teamalgo/algo/dto/UserUpdateRequest.java
@@ -1,0 +1,15 @@
+package com.teamalgo.algo.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserUpdateRequest {
+
+    private String username;
+    private String avatarUrl;
+
+}

--- a/src/main/java/com/teamalgo/algo/global/common/code/ErrorCode.java
+++ b/src/main/java/com/teamalgo/algo/global/common/code/ErrorCode.java
@@ -11,6 +11,7 @@ public enum ErrorCode implements BaseCode {
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
     NOT_FOUND(HttpStatus.NOT_FOUND, "리소스를 찾을 수 없습니다."),
     CONFLICT(HttpStatus.CONFLICT, "이미 존재하는 리소스입니다."),
+    DUPLICATE_USERNAME(HttpStatus.CONFLICT, "이미 사용 중인 사용자 이름입니다."),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류가 발생했습니다."),
     JWT_TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "토큰이 유효하지 않거나 만료되었습니다."),
     ACCESS_DENIED(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),

--- a/src/main/java/com/teamalgo/algo/service/user/UserService.java
+++ b/src/main/java/com/teamalgo/algo/service/user/UserService.java
@@ -60,6 +60,12 @@ public class UserService {
         return UserResponse.from(user);
     }
 
+    public void deleteUser(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        userRepository.delete(user);
+    }
+
     public String generateRandomUsername() {
         // UUID 이용해서 랜덤 handle 생성
         String prefix = "algo_";

--- a/src/main/java/com/teamalgo/algo/service/user/UserService.java
+++ b/src/main/java/com/teamalgo/algo/service/user/UserService.java
@@ -2,11 +2,13 @@ package com.teamalgo.algo.service.user;
 
 import com.teamalgo.algo.domain.user.User;
 import com.teamalgo.algo.dto.UserResponse;
+import com.teamalgo.algo.dto.UserUpdateRequest;
 import com.teamalgo.algo.global.common.code.ErrorCode;
 import com.teamalgo.algo.global.exception.CustomException;
 import com.teamalgo.algo.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 import java.util.UUID;
@@ -40,6 +42,22 @@ public class UserService {
                 .build();
 
         return userRepository.save(user);
+    }
+
+    @Transactional
+    public UserResponse updateUser(Long userId, UserUpdateRequest request) {
+        User user = userRepository.findById(userId).orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        if (request.getUsername() != null && !request.getUsername().equals(user.getUsername())) {
+            if (userRepository.existsByUsername(request.getUsername())) {
+                throw new CustomException(ErrorCode.DUPLICATE_USERNAME);
+            }
+            user.update(request.getUsername(), request.getAvatarUrl());
+        } else {
+            user.update(null, request.getAvatarUrl()); // 닉네임 변경 없음
+        }
+
+        return UserResponse.from(user);
     }
 
     public String generateRandomUsername() {

--- a/src/main/java/com/teamalgo/algo/service/user/UserService.java
+++ b/src/main/java/com/teamalgo/algo/service/user/UserService.java
@@ -1,6 +1,9 @@
 package com.teamalgo.algo.service.user;
 
 import com.teamalgo.algo.domain.user.User;
+import com.teamalgo.algo.dto.UserResponse;
+import com.teamalgo.algo.global.common.code.ErrorCode;
+import com.teamalgo.algo.global.exception.CustomException;
 import com.teamalgo.algo.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -16,6 +19,11 @@ public class UserService {
 
     public Optional<User> findByProviderAndProviderId(String provider, String providerId) {
         return userRepository.findByProviderAndProviderId(provider, providerId);
+    }
+
+    public UserResponse getUserInfo (Long userId) {
+        return UserResponse.from(userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND)));
     }
 
     public User saveUser(User user) {


### PR DESCRIPTION
## 💻 작업 내용  
<!-- 이번 PR에서 작업한 내용을 간단하게 적어주세요 -->
- 사용자 조회 API 구현 (`GET /api/users/me`)
- 사용자 수정 API 구현 (`PATCH /api/users/me`)
- 사용자 탈퇴 API 구현 (`DELETE /api/users/me`)

## 📌 변경 사항  
<!-- 코드 변경, 기능 추가/수정, 버그 수정 등 주요 변경 사항을 기술해주세요 -->
- [x] `UserController`에 사용자 조회/수정/탈퇴 엔드포인트 추가
- [x] `UserService`에 조회/수정/삭제 로직 구현
- [x] `UserResponse`, `UserUpdateRequest` DTO 추가
- [x] `ErrorCode`에 `DUPLICATE_USERNAME` 에러 코드 추가

## 🔗 관련 이슈  
<!-- 연결된 이슈 번호를 적어주세요 (ex. #123) -->
close #11 

## 📝 기타  
<!-- 특이사항, 참고할 점, 리뷰어에게 전달할 내용 등이 있다면 작성해주세요 -->
