### PR TITLE
[FEAT] 대시보드 조회 API 구현

### DIFF
--- a/src/main/java/com/teamalgo/algo/controller/StatsController.java
+++ b/src/main/java/com/teamalgo/algo/controller/StatsController.java
@@ -14,6 +14,7 @@ import com.teamalgo.algo.service.record.ReviewService;
 import com.teamalgo.algo.service.stats.StatsService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -45,6 +46,22 @@ public class StatsController {
                 .recentIdeas(recentIdeas)
                 .build();
 
+        return ApiResponse.success(SuccessCode._OK, response);
+    }
+
+    // 스트릭 조회
+    @GetMapping("/streak")
+    public ResponseEntity<ApiResponse<StreakCalendarResponse>> getStreak(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        Long userId = userDetails.getUser().getId();
+        StreakCalendarResponse response = statsService.getYearlyStreak(userId);
+        return ApiResponse.success(SuccessCode._OK, response);
+    }
+
+    // 사용자 통계 조회
+    @GetMapping("/stats")
+    public ResponseEntity<ApiResponse<UserStatsResponse>> getStats (@AuthenticationPrincipal CustomUserDetails userDetails) {
+        Long userId = userDetails.getUser().getId();
+        UserStatsResponse response = statsService.getUserStats(userId);
         return ApiResponse.success(SuccessCode._OK, response);
     }
 }

--- a/src/main/java/com/teamalgo/algo/controller/StatsController.java
+++ b/src/main/java/com/teamalgo/algo/controller/StatsController.java
@@ -1,0 +1,50 @@
+package com.teamalgo.algo.controller;
+
+import com.teamalgo.algo.domain.user.User;
+import com.teamalgo.algo.dto.CoreIdeaDTO;
+import com.teamalgo.algo.dto.RecordDTO;
+import com.teamalgo.algo.dto.response.DashboardResponse;
+import com.teamalgo.algo.dto.response.StreakCalendarResponse;
+import com.teamalgo.algo.dto.response.UserStatsResponse;
+import com.teamalgo.algo.global.common.api.ApiResponse;
+import com.teamalgo.algo.global.common.code.SuccessCode;
+import com.teamalgo.algo.security.CustomUserDetails;
+import com.teamalgo.algo.service.record.CoreIdeaService;
+import com.teamalgo.algo.service.record.ReviewService;
+import com.teamalgo.algo.service.stats.StatsService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/users/me")
+public class StatsController {
+
+    private final StatsService statsService;
+    private final ReviewService reviewService;
+    private final CoreIdeaService coreIdeaService;
+
+    @GetMapping("/dashboard")
+    public ResponseEntity<ApiResponse<DashboardResponse>> getDashboard(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        User user = userDetails.getUser();
+
+        DashboardResponse statsPart = statsService.getDashboard(user);
+
+        List<RecordDTO> recommendations = reviewService.getRecommendedReviews(user.getId()).stream().limit(2).toList();
+
+        List<CoreIdeaDTO> recentIdeas = coreIdeaService.getRecentIdeas(user.getId(), 2);
+
+        DashboardResponse response = statsPart.toBuilder()
+                .recommendations(recommendations)
+                .recentIdeas(recentIdeas)
+                .build();
+
+        return ApiResponse.success(SuccessCode._OK, response);
+    }
+}

--- a/src/main/java/com/teamalgo/algo/controller/UserController.java
+++ b/src/main/java/com/teamalgo/algo/controller/UserController.java
@@ -2,8 +2,6 @@ package com.teamalgo.algo.controller;
 
 import com.teamalgo.algo.dto.response.UserResponse;
 import com.teamalgo.algo.dto.request.UserUpdateRequest;
-import com.teamalgo.algo.dto.response.StreakCalendarResponse;
-import com.teamalgo.algo.dto.response.UserStatsResponse;
 import com.teamalgo.algo.global.common.api.ApiResponse;
 import com.teamalgo.algo.global.common.code.SuccessCode;
 import com.teamalgo.algo.service.stats.StatsService;
@@ -43,22 +41,6 @@ public class UserController {
         Long userId = Long.parseLong(authentication.getName());
         userService.deleteUser(userId);
         return ApiResponse.success(SuccessCode._NO_CONTENT, null);
-    }
-
-    // 스트릭 조회
-    @GetMapping("/streak")
-    public ResponseEntity<ApiResponse<StreakCalendarResponse>> getStreak(Authentication authentication) {
-        Long userId = Long.parseLong(authentication.getName());
-        StreakCalendarResponse response = statsService.getYearlyStreak(userId);
-        return ApiResponse.success(SuccessCode._OK, response);
-    }
-
-    // 사용자 통계 조회
-    @GetMapping("/stats")
-    public ResponseEntity<ApiResponse<UserStatsResponse>> getStats (Authentication authentication) {
-        Long userId = Long.parseLong(authentication.getName());
-        UserStatsResponse response = statsService.getUserStats(userId);
-        return ApiResponse.success(SuccessCode._OK, response);
     }
 
 }

--- a/src/main/java/com/teamalgo/algo/dto/response/DashboardResponse.java
+++ b/src/main/java/com/teamalgo/algo/dto/response/DashboardResponse.java
@@ -1,0 +1,23 @@
+package com.teamalgo.algo.dto.response;
+
+import com.teamalgo.algo.dto.CoreIdeaDTO;
+import com.teamalgo.algo.dto.RecordDTO;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder(toBuilder = true)
+@AllArgsConstructor
+public class DashboardResponse {
+
+    private int recordCount;
+    private int streakDays;
+    private double successRate;
+    private int bookmarkCount;
+    private List<RecordDTO> recommendations;
+    private List<CoreIdeaDTO> recentIdeas;
+
+}

--- a/src/main/java/com/teamalgo/algo/repository/RecordCoreIdeaRepository.java
+++ b/src/main/java/com/teamalgo/algo/repository/RecordCoreIdeaRepository.java
@@ -14,6 +14,9 @@ public interface RecordCoreIdeaRepository extends JpaRepository<RecordCoreIdea, 
     // 특정 유저의 레코드에서 나온 아이디어만 조회
     List<RecordCoreIdea> findByRecordUserId(Long userId);
 
+    // 최신순 조회
+    List<RecordCoreIdea> findByRecordUserIdOrderByRecordCreatedAtDesc(Long userId, Pageable pageable);
+
     @Query("""
         SELECT c.name, COUNT(idea.id) as ideaCount
         FROM RecordCoreIdea idea

--- a/src/main/java/com/teamalgo/algo/service/record/CoreIdeaService.java
+++ b/src/main/java/com/teamalgo/algo/service/record/CoreIdeaService.java
@@ -3,6 +3,7 @@ package com.teamalgo.algo.service.record;
 import com.teamalgo.algo.dto.CoreIdeaDTO;
 import com.teamalgo.algo.repository.RecordCoreIdeaRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -17,6 +18,13 @@ public class CoreIdeaService {
 
     public List<CoreIdeaDTO> getUserIdeas(Long userId) {
         return recordCoreIdeaRepository.findByRecordUserId(userId)
+                .stream()
+                .map(CoreIdeaDTO::fromEntity)
+                .toList();
+    }
+
+    public List<CoreIdeaDTO> getRecentIdeas(Long userId, int limit) {
+        return recordCoreIdeaRepository.findByRecordUserIdOrderByRecordCreatedAtDesc(userId, PageRequest.of(0, limit))
                 .stream()
                 .map(CoreIdeaDTO::fromEntity)
                 .toList();


### PR DESCRIPTION
## 💻 작업 내용
- 대시보드 조회 API 구현 (`GET /api/users/me/dashboard`)

## 📌 변경 사항
- [x] DashboardResponse DTO 추가  
- [x] StatsService 대시보드 통계 조회 기능 구현
- [x] CoreIdeaService 최근 아이디어 조회 로직 추가
- [x] streak/stats API를 UserController → StatsController로 이동  

## 🔗 관련 이슈
close #21 

## 📝 기타
