### PR TITLE
[FEAT] 문제 매핑 // 내 기록 & 임시 저장 목록 조회 API 구현 // 페이지네이션 추가

### DIFF
--- a/src/main/java/com/teamalgo/algo/controller/BookmarkController.java
+++ b/src/main/java/com/teamalgo/algo/controller/BookmarkController.java
@@ -2,6 +2,7 @@ package com.teamalgo.algo.controller;
 
 import com.teamalgo.algo.domain.user.User;
 import com.teamalgo.algo.dto.RecordDTO;
+import com.teamalgo.algo.dto.response.BookmarkListResponse;
 import com.teamalgo.algo.global.common.api.ApiResponse;
 import com.teamalgo.algo.global.common.code.SuccessCode;
 import com.teamalgo.algo.security.CustomUserDetails;
@@ -13,8 +14,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.PageRequest;
 
-import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -52,13 +55,18 @@ public class BookmarkController {
 
     // 북마크 목록 조회
     @GetMapping
-    public ResponseEntity<ApiResponse<List<RecordDTO>>> getBookmarks(
-            @AuthenticationPrincipal CustomUserDetails userDetails
+    public ResponseEntity<ApiResponse<BookmarkListResponse>> getMyBookmarks(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
     ) {
-        User user = userService.findById(userDetails.getUser().getId())
-                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        User user = userDetails.getUser();
 
-        var response = bookmarkService.getBookmarkedRecords(user);
+        Page<RecordDTO> bookmarks = bookmarkService.getBookmarkedRecords(user, PageRequest.of(page, size));
+        BookmarkListResponse response = BookmarkListResponse.fromPage(bookmarks);
+
         return ApiResponse.success(SuccessCode._OK, response);
     }
+
+
 }

--- a/src/main/java/com/teamalgo/algo/controller/CoreIdeaController.java
+++ b/src/main/java/com/teamalgo/algo/controller/CoreIdeaController.java
@@ -2,6 +2,7 @@ package com.teamalgo.algo.controller;
 
 import com.teamalgo.algo.domain.user.User;
 import com.teamalgo.algo.dto.CoreIdeaDTO;
+import com.teamalgo.algo.dto.response.CoreIdeaListResponse;
 import com.teamalgo.algo.global.common.api.ApiResponse;
 import com.teamalgo.algo.global.common.code.SuccessCode;
 import com.teamalgo.algo.global.exception.CustomException;
@@ -14,8 +15,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
-
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/users/me")
@@ -26,13 +27,19 @@ public class CoreIdeaController {
 
     // 내 아이디어 전체 조회
     @GetMapping("/ideas")
-    public ResponseEntity<ApiResponse<List<CoreIdeaDTO>>> getMyIdeas(
-            @AuthenticationPrincipal CustomUserDetails userDetails
+    public ResponseEntity<ApiResponse<CoreIdeaListResponse>> getMyIdeas(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
     ) {
         User user = userService.findById(userDetails.getUser().getId())
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
-        List<CoreIdeaDTO> ideas = coreIdeaService.getUserIdeas(user.getId());
-        return ApiResponse.success(SuccessCode._OK, ideas);
+        Page<CoreIdeaDTO> ideas = coreIdeaService.getUserIdeas(user.getId(), PageRequest.of(page, size));
+        CoreIdeaListResponse response = CoreIdeaListResponse.fromPage(ideas);
+
+        return ApiResponse.success(SuccessCode._OK, response);
     }
+
+
 }

--- a/src/main/java/com/teamalgo/algo/controller/DraftRecordController.java
+++ b/src/main/java/com/teamalgo/algo/controller/DraftRecordController.java
@@ -1,0 +1,36 @@
+package com.teamalgo.algo.controller;
+
+import com.teamalgo.algo.domain.user.User;
+import com.teamalgo.algo.dto.response.RecordListResponse;
+import com.teamalgo.algo.dto.response.RecordResponse;
+import com.teamalgo.algo.global.common.api.ApiResponse;
+import com.teamalgo.algo.global.common.code.SuccessCode;
+import com.teamalgo.algo.security.CustomUserDetails;
+import com.teamalgo.algo.service.record.RecordService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/users/me/drafts")
+public class DraftRecordController {
+
+    private final RecordService recordService;
+
+    // Draft 목록 조회
+    @GetMapping
+    public ResponseEntity<ApiResponse<RecordListResponse.Data>> getMyDrafts(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        User user = userDetails.getUser();
+        Page<com.teamalgo.algo.domain.record.Record> drafts = recordService.getDraftsByUser(user, PageRequest.of(page, size));
+        RecordListResponse.Data response = recordService.createRecordListResponse(drafts);
+        return ApiResponse.success(SuccessCode._OK, response);
+    }
+}

--- a/src/main/java/com/teamalgo/algo/controller/MyRecordController.java
+++ b/src/main/java/com/teamalgo/algo/controller/MyRecordController.java
@@ -1,0 +1,36 @@
+package com.teamalgo.algo.controller;
+
+import com.teamalgo.algo.domain.user.User;
+import com.teamalgo.algo.dto.response.RecordListResponse;
+import com.teamalgo.algo.global.common.api.ApiResponse;
+import com.teamalgo.algo.global.common.code.SuccessCode;
+import com.teamalgo.algo.security.CustomUserDetails;
+import com.teamalgo.algo.service.record.RecordService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/users/me/records")
+public class MyRecordController {
+
+    private final RecordService recordService;
+
+    // 내 기록 목록 조회
+    @GetMapping
+    public ResponseEntity<ApiResponse<RecordListResponse.Data>> getMyRecords(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        User user = userDetails.getUser();
+        Page<com.teamalgo.algo.domain.record.Record> records = recordService.getRecordsByUser(user, PageRequest.of(page, size));
+        RecordListResponse.Data response = recordService.createRecordListResponse(records);
+        return ApiResponse.success(SuccessCode._OK, response);
+    }
+
+}

--- a/src/main/java/com/teamalgo/algo/dto/request/RecordCreateRequest.java
+++ b/src/main/java/com/teamalgo/algo/dto/request/RecordCreateRequest.java
@@ -19,9 +19,6 @@ public class RecordCreateRequest {
     @NotBlank(message = "Problem URL cannot be blank")
     private String problemUrl;
 
-    @NotNull(message = "Problem source cannot be null")
-    private String source;
-
     @NotBlank(message = "Problem title cannot be blank")
     private String title;
 
@@ -37,7 +34,7 @@ public class RecordCreateRequest {
     private int difficulty;
 
     @Size(max = 500, message = "Detail should not exceed 500 characters")
-    private String detail;      // 풀이 상세 설명
+    private String detail;
 
     private List<RecordCodeDTO> codes;
     private List<RecordStepDTO> steps;

--- a/src/main/java/com/teamalgo/algo/dto/response/BookmarkListResponse.java
+++ b/src/main/java/com/teamalgo/algo/dto/response/BookmarkListResponse.java
@@ -1,0 +1,32 @@
+package com.teamalgo.algo.dto.response;
+
+import com.teamalgo.algo.dto.RecordDTO;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class BookmarkListResponse {
+    private List<RecordDTO> bookmarks;
+
+    private int page;
+    private int size;
+    private long totalElements;
+    private int totalPages;
+    private boolean first;
+    private boolean last;
+
+    public static BookmarkListResponse fromPage(org.springframework.data.domain.Page<RecordDTO> pageData) {
+        return BookmarkListResponse.builder()
+                .bookmarks(pageData.getContent())
+                .page(pageData.getNumber() + 1) // 0-based → 1-based
+                .size(pageData.getSize())
+                .totalElements(pageData.getTotalElements())
+                .totalPages(pageData.getTotalPages())
+                .first(pageData.isFirst())
+                .last(pageData.isLast())
+                .build();
+    }
+}

--- a/src/main/java/com/teamalgo/algo/dto/response/CoreIdeaListResponse.java
+++ b/src/main/java/com/teamalgo/algo/dto/response/CoreIdeaListResponse.java
@@ -1,0 +1,33 @@
+package com.teamalgo.algo.dto.response;
+
+import com.teamalgo.algo.dto.CoreIdeaDTO;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class CoreIdeaListResponse {
+
+    private List<CoreIdeaDTO> ideas;
+
+    private int page;
+    private int size;
+    private long totalElements;
+    private int totalPages;
+    private boolean first;
+    private boolean last;
+
+    public static CoreIdeaListResponse fromPage(org.springframework.data.domain.Page<CoreIdeaDTO> pageData) {
+        return CoreIdeaListResponse.builder()
+                .ideas(pageData.getContent())
+                .page(pageData.getNumber() + 1) // 0-based → 1-based
+                .size(pageData.getSize())
+                .totalElements(pageData.getTotalElements())
+                .totalPages(pageData.getTotalPages())
+                .first(pageData.isFirst())
+                .last(pageData.isLast())
+                .build();
+    }
+}

--- a/src/main/java/com/teamalgo/algo/global/common/util/ProblemSourceDetector.java
+++ b/src/main/java/com/teamalgo/algo/global/common/util/ProblemSourceDetector.java
@@ -1,0 +1,59 @@
+package com.teamalgo.algo.global.common.util;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class ProblemSourceDetector {
+
+    public static String detectSource(String url) {
+        if (url.contains("acmicpc.net")) return "boj";
+        if (url.contains("programmers.co.kr")) return "programmers";
+        if (url.contains("leetcode.com")) return "leetcode";
+        if (url.contains("codeforces.com")) return "codeforces";
+        return "unknown";
+    }
+
+    public static String extractExternalId(String url, String source) {
+        try {
+            URI uri = new URI(url);
+
+            switch (source) {
+                case "boj": {
+                    // https://www.acmicpc.net/problem/1000
+                    Pattern pattern = Pattern.compile("/problem/(\\d+)");
+                    Matcher matcher = pattern.matcher(uri.getPath());
+                    if (matcher.find()) return matcher.group(1);
+                    break;
+                }
+                case "programmers": {
+                    // https://school.programmers.co.kr/learn/courses/30/lessons/42576
+                    Pattern pattern = Pattern.compile("/lessons/(\\d+)");
+                    Matcher matcher = pattern.matcher(uri.getPath());
+                    if (matcher.find()) return matcher.group(1);
+                    break;
+                }
+                case "leetcode": {
+                    // https://leetcode.com/problems/two-sum/
+                    Pattern pattern = Pattern.compile("/problems/([a-z0-9-]+)/?");
+                    Matcher matcher = pattern.matcher(uri.getPath());
+                    if (matcher.find()) return matcher.group(1);
+                    break;
+                }
+                case "codeforces": {
+                    // https://codeforces.com/problemset/problem/4/A
+                    Pattern pattern = Pattern.compile("/problemset/problem/(\\d+)/(\\w+)");
+                    Matcher matcher = pattern.matcher(uri.getPath());
+                    if (matcher.find()) return matcher.group(1) + matcher.group(2);
+                    break;
+                }
+                default:
+                    return "unknown";
+            }
+        } catch (URISyntaxException e) {
+            throw new IllegalArgumentException("Invalid URL format: " + url, e);
+        }
+        return "unknown";
+    }
+}

--- a/src/main/java/com/teamalgo/algo/repository/BookmarkRepository.java
+++ b/src/main/java/com/teamalgo/algo/repository/BookmarkRepository.java
@@ -6,7 +6,8 @@ import com.teamalgo.algo.domain.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -17,6 +18,8 @@ public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
     // 북마크 엔터티 가져와서 삭제할 때
     Optional<Bookmark> findByUserAndRecord(User user, Record record);
     // RecordDTO 형태로 북마크 목록 반환
+
+    Page<Bookmark> findByUser(User user, Pageable pageable);
     List<Bookmark> findByUser(User user);
     // 사용자 별 전체 북마크 수
     Long countByUser(User user);

--- a/src/main/java/com/teamalgo/algo/repository/RecordCoreIdeaRepository.java
+++ b/src/main/java/com/teamalgo/algo/repository/RecordCoreIdeaRepository.java
@@ -6,16 +6,17 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import java.util.List;
 
 public interface RecordCoreIdeaRepository extends JpaRepository<RecordCoreIdea, Long> {
 
-    // 특정 유저의 레코드에서 나온 아이디어만 조회
-    List<RecordCoreIdea> findByRecordUserId(Long userId);
+    // 특정 유저의 레코드에서 나온 아이디어 페이지네이션 조회
+    Page<RecordCoreIdea> findByRecordUserId(Long userId, Pageable pageable);
 
-    // 최신순 조회
-    List<RecordCoreIdea> findByRecordUserIdOrderByRecordCreatedAtDesc(Long userId, Pageable pageable);
+    // 최신순 페이지네이션 조회
+    Page<RecordCoreIdea> findByRecordUserIdOrderByRecordCreatedAtDesc(Long userId, Pageable pageable);
 
     @Query("""
         SELECT c.name, COUNT(idea.id) as ideaCount

--- a/src/main/java/com/teamalgo/algo/repository/RecordRepository.java
+++ b/src/main/java/com/teamalgo/algo/repository/RecordRepository.java
@@ -2,7 +2,8 @@ package com.teamalgo.algo.repository;
 
 import com.teamalgo.algo.domain.record.Record;
 import org.springframework.data.jpa.repository.JpaRepository;
-
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import java.util.List;
 import java.util.Optional;
 
@@ -13,5 +14,10 @@ public interface RecordRepository extends JpaRepository<Record, Long> {
     List<Record> findByUserId(Long userId);
 
     Optional<Record> findByIdAndUserId(Long recordId, Long userID);
+
+    Page<Record> findByUserId(Long userId, Pageable pageable);
+
+    Page<com.teamalgo.algo.domain.record.Record> findByUserIdAndIsDraftTrue(Long userId, Pageable pageable);
+
 
 }

--- a/src/main/java/com/teamalgo/algo/service/record/BookmarkService.java
+++ b/src/main/java/com/teamalgo/algo/service/record/BookmarkService.java
@@ -11,8 +11,8 @@ import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 @Service
 @RequiredArgsConstructor
@@ -53,10 +53,8 @@ public class BookmarkService {
     }
 
     // 북마크한 레코드 목록 조회
-    public List<RecordDTO> getBookmarkedRecords(User user) {
-        return bookmarkRepository.findByUser(user).stream()
-                .map(Bookmark::getRecord)
-                .map(RecordDTO::from)
-                .toList();
+    public Page<RecordDTO> getBookmarkedRecords(User user, Pageable pageable) {
+        return bookmarkRepository.findByUser(user, pageable)
+                .map(bookmark -> RecordDTO.from(bookmark.getRecord()));
     }
 }

--- a/src/main/java/com/teamalgo/algo/service/record/CoreIdeaService.java
+++ b/src/main/java/com/teamalgo/algo/service/record/CoreIdeaService.java
@@ -6,7 +6,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import java.util.List;
 
 @Service
@@ -16,18 +17,18 @@ public class CoreIdeaService {
 
     private final RecordCoreIdeaRepository recordCoreIdeaRepository;
 
-    public List<CoreIdeaDTO> getUserIdeas(Long userId) {
-        return recordCoreIdeaRepository.findByRecordUserId(userId)
+    public Page<CoreIdeaDTO> getUserIdeas(Long userId, Pageable pageable) {
+        return recordCoreIdeaRepository.findByRecordUserId(userId, pageable)
+                .map(CoreIdeaDTO::fromEntity);
+    }
+
+    public List<CoreIdeaDTO> getRecentIdeas(Long userId, int limit) {
+        Pageable pageable = PageRequest.of(0, limit);
+        return recordCoreIdeaRepository.findByRecordUserIdOrderByRecordCreatedAtDesc(userId, pageable)
                 .stream()
                 .map(CoreIdeaDTO::fromEntity)
                 .toList();
     }
 
-    public List<CoreIdeaDTO> getRecentIdeas(Long userId, int limit) {
-        return recordCoreIdeaRepository.findByRecordUserIdOrderByRecordCreatedAtDesc(userId, PageRequest.of(0, limit))
-                .stream()
-                .map(CoreIdeaDTO::fromEntity)
-                .toList();
-    }
 }
 

--- a/src/main/java/com/teamalgo/algo/service/record/RecordService.java
+++ b/src/main/java/com/teamalgo/algo/service/record/RecordService.java
@@ -22,7 +22,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -137,6 +136,16 @@ public class RecordService {
         Pageable pageable = PageRequest.of(req.getPageIndex(), req.getSize(), sort);
 
         return recordRepository.findAll(pageable);
+    }
+
+    // 내 레코드 목록 조회
+    public Page<com.teamalgo.algo.domain.record.Record> getRecordsByUser(User user, Pageable pageable) {
+        return recordRepository.findByUserId(user.getId(), pageable);
+    }
+
+    // Draft 목록 조회
+    public Page<com.teamalgo.algo.domain.record.Record> getDraftsByUser(User user, Pageable pageable) {
+        return recordRepository.findByUserIdAndIsDraftTrue(user.getId(), pageable);
     }
 
     // 레코드 수정
@@ -272,6 +281,7 @@ public class RecordService {
                 .last(records.isLast())
                 .build();
     }
+
 
     // --- 매핑 헬퍼 ---
     private ProblemDTO mapProblem(Problem problem) {

--- a/src/main/java/com/teamalgo/algo/service/record/RecordService.java
+++ b/src/main/java/com/teamalgo/algo/service/record/RecordService.java
@@ -11,8 +11,8 @@ import com.teamalgo.algo.dto.request.RecordUpdateRequest;
 import com.teamalgo.algo.dto.response.RecordListResponse;
 import com.teamalgo.algo.dto.response.RecordResponse;
 import com.teamalgo.algo.repository.*;
-
 import com.teamalgo.algo.service.stats.StatsService;
+import com.teamalgo.algo.global.common.util.ProblemSourceDetector;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.*;
@@ -22,6 +22,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -38,14 +39,20 @@ public class RecordService {
     @Transactional
     public com.teamalgo.algo.domain.record.Record createRecord(User user, RecordCreateRequest req) {
         Problem problem = problemRepository.findByUrl(req.getProblemUrl())
-                .orElseGet(() -> problemRepository.save(
-                        Problem.builder()
-                                .url(req.getProblemUrl())
-                                .title(req.getTitle())
-                                .source(req.getSource())
-                                .externalId(UUID.randomUUID().toString())
-                                .build()
-                ));
+                .orElseGet(() -> {
+                    // URL → source, externalId 자동 매핑
+                    String source = ProblemSourceDetector.detectSource(req.getProblemUrl());
+                    String externalId = ProblemSourceDetector.extractExternalId(req.getProblemUrl(), source);
+
+                    return problemRepository.save(
+                            Problem.builder()
+                                    .url(req.getProblemUrl())
+                                    .title(req.getTitle())
+                                    .source(source)
+                                    .externalId(externalId)
+                                    .build()
+                    );
+                });
 
         com.teamalgo.algo.domain.record.Record record = com.teamalgo.algo.domain.record.Record.builder()
                 .user(user)
@@ -57,7 +64,7 @@ public class RecordService {
                 .isPublished(req.isPublished())
                 .build();
 
-        // Codes (항상 서버에서 snippetOrder 재지정)
+        // Codes
         if (req.getCodes() != null) {
             AtomicInteger order = new AtomicInteger(0);
             for (RecordCodeDTO dto : req.getCodes()) {
@@ -67,7 +74,7 @@ public class RecordService {
             }
         }
 
-        // Steps (항상 서버에서 stepOrder 재지정)
+        // Steps
         if (req.getSteps() != null) {
             AtomicInteger order = new AtomicInteger(0);
             for (RecordStepDTO dto : req.getSteps()) {
@@ -79,11 +86,13 @@ public class RecordService {
 
         if (req.getIdeas() != null) {
             record.getIdeas().addAll(req.getIdeas().stream()
-                    .map(dto -> dto.toEntity(record)).toList());
+                    .map(dto -> dto.toEntity(record))
+                    .toList());
         }
         if (req.getLinks() != null) {
             record.getLinks().addAll(req.getLinks().stream()
-                    .map(dto -> dto.toEntity(record)).toList());
+                    .map(dto -> dto.toEntity(record))
+                    .toList());
         }
 
         if (req.getCategories() != null) {
@@ -106,19 +115,20 @@ public class RecordService {
             record.getRecordCategories().addAll(recordCategories);
         }
 
-        // 스트릭 기록
-        Boolean isSuccess = record.getStatus().equals("success");
+        //  성공/실패 기록 반영
+        boolean isSuccess = record.getStatus().equals("success");
         statsService.updateStats(user, isSuccess);
 
         return recordRepository.save(record);
     }
 
-    // 조회
+    // 레코드 단건 조회
     public com.teamalgo.algo.domain.record.Record getRecordById(Long id) {
         return recordRepository.findById(id)
                 .orElseThrow(() -> new EntityNotFoundException("Record not found: " + id));
     }
 
+    // 레코드 목록 조회
     public Page<com.teamalgo.algo.domain.record.Record> searchRecords(RecordSearchRequest req) {
         Sort sort = (req.getSort() == RecordSearchRequest.SortType.LATEST)
                 ? Sort.by(Sort.Direction.DESC, "createdAt")
@@ -129,7 +139,7 @@ public class RecordService {
         return recordRepository.findAll(pageable);
     }
 
-    // 레코드 수정 (블로그 전체 교체 방식)
+    // 레코드 수정
     @Transactional
     public com.teamalgo.algo.domain.record.Record updateRecord(
             Long id,
@@ -142,12 +152,12 @@ public class RecordService {
             throw new AccessDeniedException("권한이 없습니다.");
         }
 
-        // --- 단일 필드 갱신 ---
+        // 단일 필드 업데이트
         record.updateDetail(req.getDetail());
         if (req.getIsDraft() != null) record.updateDraft(req.getIsDraft());
         if (req.getIsPublished() != null) record.updatePublished(req.getIsPublished());
 
-        // --- Codes 전체 교체 ---
+        // Codes 교체
         if (req.getCodes() != null) {
             record.getCodes().clear();
             recordRepository.flush();
@@ -159,7 +169,7 @@ public class RecordService {
             }
         }
 
-        // --- Steps 전체 교체 ---
+        // Steps 교체
         if (req.getSteps() != null) {
             record.getSteps().clear();
             recordRepository.flush();
@@ -171,7 +181,7 @@ public class RecordService {
             }
         }
 
-        // --- Ideas 전체 교체 ---
+        // Ideas 교체
         if (req.getIdeas() != null) {
             record.getIdeas().clear();
             recordRepository.flush();
@@ -180,7 +190,7 @@ public class RecordService {
             }
         }
 
-        // --- Links 전체 교체 ---
+        // Links 교체
         if (req.getLinks() != null) {
             record.getLinks().clear();
             recordRepository.flush();
@@ -189,7 +199,7 @@ public class RecordService {
             }
         }
 
-        // --- Categories 전체 교체 ---
+        // Categories 교체
         if (req.getCategories() != null) {
             record.getRecordCategories().clear();
             recordRepository.flush();
@@ -212,7 +222,6 @@ public class RecordService {
 
         return record;
     }
-
 
     // 레코드 삭제
     @Transactional


### PR DESCRIPTION
## 💻 작업 내용  
<!-- 이번 PR에서 작업한 내용을 간단하게 적어주세요 -->

- 문제 URL 자동 매핑 기능 구현 (출처 및 externalId 자동 추출)
- 내 기록 조회 API 구현 (GET /api/users/me/records)
- 임시 저장(Draft) 기록 조회 API 구현 (GET /api/users/me/drafts)
- 북마크, 핵심 아이디어 페이지네이션 추가

## 📌 변경 사항  
<!-- 코드 변경, 기능 추가/수정, 버그 수정 등 주요 변경 사항을 기술해주세요 -->
- [x] ProblemSourceDetector 유틸 추가 (문제 출처 및 externalId 매핑)
- [x] RecordService 문제 생성 로직에 URL 매핑 적용
- [x] MyRecordController 추가 → 내 기록 목록 조회 API 제공
- [x] DraftRecordController 추가 → draft 기록 목록 조회 API 제공
- [x] RecordService에 내 기록 조회 및 draft 레코드 조회 메서드 추가 
- [x] BookmarkListResponse / CoreIdeaListResponse 추가

## 📝 기타  
<!-- 특이사항, 참고할 점, 리뷰어에게 전달할 내용 등이 있다면 작성해주세요 -->

- Draft / MyRecord API는 목록 조회까지만 구현
- 목록 -> 특정 항목 클릭 -> ID로 단일 조회 API 호출 -> (수정 시에 PUT 요청)