### PR TITLE
[FEAT] 유형 분포 조회 API 구현

### DIFF
--- a/src/main/java/com/teamalgo/algo/controller/StatsController.java
+++ b/src/main/java/com/teamalgo/algo/controller/StatsController.java
@@ -3,6 +3,7 @@ package com.teamalgo.algo.controller;
 import com.teamalgo.algo.domain.user.User;
 import com.teamalgo.algo.dto.CoreIdeaDTO;
 import com.teamalgo.algo.dto.RecordDTO;
+import com.teamalgo.algo.dto.response.CategoryStatsResponse;
 import com.teamalgo.algo.dto.response.DashboardResponse;
 import com.teamalgo.algo.dto.response.StreakCalendarResponse;
 import com.teamalgo.algo.dto.response.UserStatsResponse;
@@ -11,6 +12,7 @@ import com.teamalgo.algo.global.common.code.SuccessCode;
 import com.teamalgo.algo.security.CustomUserDetails;
 import com.teamalgo.algo.service.record.CoreIdeaService;
 import com.teamalgo.algo.service.record.ReviewService;
+import com.teamalgo.algo.service.stats.CategoryStatsService;
 import com.teamalgo.algo.service.stats.StatsService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -30,6 +32,7 @@ public class StatsController {
     private final StatsService statsService;
     private final ReviewService reviewService;
     private final CoreIdeaService coreIdeaService;
+    private final CategoryStatsService categoryStatsService;
 
     @GetMapping("/dashboard")
     public ResponseEntity<ApiResponse<DashboardResponse>> getDashboard(@AuthenticationPrincipal CustomUserDetails userDetails) {
@@ -64,4 +67,13 @@ public class StatsController {
         UserStatsResponse response = statsService.getUserStats(userId);
         return ApiResponse.success(SuccessCode._OK, response);
     }
+
+    // 유형 분포 조회
+    @GetMapping("/categories")
+    public ResponseEntity<ApiResponse<List<CategoryStatsResponse>>> getCategoryStats(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        Long userId = userDetails.getUser().getId();
+        List<CategoryStatsResponse> response = categoryStatsService.getCategoryStats(userId);
+        return ApiResponse.success(SuccessCode._OK, response);
+    }
+
 }

--- a/src/main/java/com/teamalgo/algo/dto/response/CategoryStatsResponse.java
+++ b/src/main/java/com/teamalgo/algo/dto/response/CategoryStatsResponse.java
@@ -1,0 +1,22 @@
+package com.teamalgo.algo.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CategoryStatsResponse {
+
+    private String slug;
+    private String name;
+    private Long count;
+    private Double ratio;
+
+    public CategoryStatsResponse(String slug, String name, Long count) {
+        this.slug = slug;
+        this.name = name;
+        this.count = count;
+        this.ratio = 0.0;
+    }
+
+}

--- a/src/main/java/com/teamalgo/algo/repository/RecordCategoryRepository.java
+++ b/src/main/java/com/teamalgo/algo/repository/RecordCategoryRepository.java
@@ -2,6 +2,7 @@ package com.teamalgo.algo.repository;
 
 import com.teamalgo.algo.domain.category.RecordCategory;
 import com.teamalgo.algo.domain.user.User;
+import com.teamalgo.algo.dto.response.CategoryStatsResponse;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -21,5 +22,12 @@ public interface RecordCategoryRepository extends JpaRepository<RecordCategory, 
         ORDER BY solvedCount DESC
     """)
     List<Object[]> findMostSolvedByUser(@Param("user") User user, Pageable pageable);
+
+    @Query("SELECT new com.teamalgo.algo.dto.response.CategoryStatsResponse(c.slug, c.name, COUNT(rc)) " +
+            "FROM RecordCategory rc " +
+            "JOIN rc.category c " +
+            "WHERE rc.record.user.id = :userId " +
+            "GROUP BY c.slug, c.name")
+    List<CategoryStatsResponse> findCategoryCountsByUserId(@Param("userId") Long userId);
 
 }

--- a/src/main/java/com/teamalgo/algo/service/stats/CategoryStatsService.java
+++ b/src/main/java/com/teamalgo/algo/service/stats/CategoryStatsService.java
@@ -1,0 +1,33 @@
+package com.teamalgo.algo.service.stats;
+
+import com.teamalgo.algo.dto.response.CategoryStatsResponse;
+import com.teamalgo.algo.repository.RecordCategoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class CategoryStatsService {
+
+    private final RecordCategoryRepository recordCategoryRepository;
+
+    public List<CategoryStatsResponse> getCategoryStats(Long userId) {
+        List<CategoryStatsResponse> results = recordCategoryRepository.findCategoryCountsByUserId(userId);
+
+        Long total = results.stream()
+                        .mapToLong(CategoryStatsResponse::getCount)
+                        .sum();
+
+        return results.stream()
+                .map(r -> new CategoryStatsResponse(
+                        r.getSlug(),
+                        r.getName(),
+                        r.getCount(),
+                        Math.round(((double) r.getCount() / total) * 1000) / 10.0
+                ))
+                .toList();
+    }
+
+}


### PR DESCRIPTION
## 💻 작업 내용  
- 유형 분포 조회 API 구현 (`GET /api/users/me/categories`)

## 📌 변경 사항  
- [x] `CategoryStatsResponse` DTO 추가  
- [x] `RecordCategoryRepository` → 카테고리별 집계 쿼리 작성  
- [x] `CategoryStatsService` → 전체 대비 비율(`ratio`) 계산 로직 추가  
- [x] `UserCategoryController` → `/api/users/me/categories` 엔드포인트 구현  

## 🔗 관련 이슈  

## 📝 기타
