### PR TITLE
[FEAT] Record 검색 기능, ProblemSourceDetector 수정, 날짜 포맷 개선

### DIFF
--- a/src/main/java/com/teamalgo/algo/domain/problem/Problem.java
+++ b/src/main/java/com/teamalgo/algo/domain/problem/Problem.java
@@ -12,7 +12,7 @@ import lombok.*;
 @Table(
         name = "problem",
         uniqueConstraints = {
-                @UniqueConstraint(columnNames = {"source", "externalId"})
+                @UniqueConstraint(columnNames = {"source", "numericId", "slugId"})
         }
 )
 public class Problem extends BaseEntity {
@@ -24,12 +24,17 @@ public class Problem extends BaseEntity {
     @Column(nullable = false)
     private String source;
 
-    @Column(nullable = false)
-    private String externalId;
+    private Long numericId;   // BOJ, Programmers, CodeUp, Codeforces
+
+    private String slugId;    // LeetCode 등 slug 기반
 
     @Column(nullable = false)
     private String url;
 
     @Column(nullable = false)
     private String title;
+
+    public String getDisplayId() {
+        return numericId != null ? String.valueOf(numericId) : null;
+    }
 }

--- a/src/main/java/com/teamalgo/algo/dto/ProblemDTO.java
+++ b/src/main/java/com/teamalgo/algo/dto/ProblemDTO.java
@@ -1,15 +1,14 @@
 package com.teamalgo.algo.dto;
+
 import lombok.Builder;
 import lombok.Getter;
-import lombok.Setter;
 
 @Getter
-@Setter
 @Builder
 public class ProblemDTO {
-    private Long id;        // 문제 ID
-    private String source;  // 문제 출처 (boj, leetcode 등)
-    private String externalId; // 출처 내 문제 식별자
-    private String url;     // 문제 URL
-    private String title;   // 문제 제목
+    private Long id;          // DB PK
+    private String source;    // 문제 출처 (백준, 리트코드 등)
+    private String displayId; // 숫자 기반 문제 번호 있으면 채움, slug 기반이면 null
+    private String url;       // 문제 URL
+    private String title;     // 문제 제목
 }

--- a/src/main/java/com/teamalgo/algo/dto/RecordCodeDTO.java
+++ b/src/main/java/com/teamalgo/algo/dto/RecordCodeDTO.java
@@ -21,11 +21,11 @@ import com.teamalgo.algo.domain.record.Record;
 public class RecordCodeDTO {
     private Long id; // Create 시 null, Update/Response 시 존재
 
-    @NotNull(message = "Language cannot be null")
-    private String language;
-
     @NotNull(message = "Code cannot be null")
     private String code;
+
+    @NotNull(message = "Language cannot be null")
+    private String language;
 
     @NotNull(message = "Verdict cannot be null")
     @Pattern(regexp = "pass|fail", message = "Verdict must be 'pass' or 'fail'")

--- a/src/main/java/com/teamalgo/algo/dto/RecordDTO.java
+++ b/src/main/java/com/teamalgo/algo/dto/RecordDTO.java
@@ -4,6 +4,7 @@ import lombok.Getter;
 import lombok.Setter;
 
 import com.teamalgo.algo.domain.record.Record;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -11,11 +12,12 @@ import java.util.List;
 @Setter
 @Builder
 public class RecordDTO {
+    private Long id;
+    private String title;
+    private List<String> categories;
+    private String author;
 
-    private Long id;           // 풀이 기록 ID
-    private String title;      // 문제 제목
-    private List<String> categories; // 문제 카테고리 리스트
-    private String author;     // 작성자 닉네임
+    @JsonFormat(pattern = "yyyy.MM.dd", timezone = "Asia/Seoul")
     private LocalDateTime createdAt;
 
     public static RecordDTO from(Record record) {

--- a/src/main/java/com/teamalgo/algo/dto/request/RecordCreateRequest.java
+++ b/src/main/java/com/teamalgo/algo/dto/request/RecordCreateRequest.java
@@ -33,7 +33,7 @@ public class RecordCreateRequest {
     @Max(value = 5, message = "Difficulty must be between 1 and 5")
     private int difficulty;
 
-    @Size(max = 500, message = "Detail should not exceed 500 characters")
+    @Size(max = 2000, message = "Detail should not exceed 2000 characters")
     private String detail;
 
     private List<RecordCodeDTO> codes;

--- a/src/main/java/com/teamalgo/algo/dto/response/RecordResponse.java
+++ b/src/main/java/com/teamalgo/algo/dto/response/RecordResponse.java
@@ -4,7 +4,7 @@ import com.teamalgo.algo.dto.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
-
+import com.fasterxml.jackson.annotation.JsonFormat;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -38,7 +38,10 @@ public class RecordResponse {
         private Boolean isBookmarked;
         private Boolean isOwner;
 
+        @JsonFormat(pattern = "yyyy.MM.dd HH:mm")
         private LocalDateTime createdAt;
+
+        @JsonFormat(pattern = "yyyy.MM.dd HH:mm")
         private LocalDateTime updatedAt;
     }
 }

--- a/src/main/java/com/teamalgo/algo/global/common/util/ProblemSourceDetector.java
+++ b/src/main/java/com/teamalgo/algo/global/common/util/ProblemSourceDetector.java
@@ -8,52 +8,74 @@ import java.util.regex.Pattern;
 public class ProblemSourceDetector {
 
     public static String detectSource(String url) {
-        if (url.contains("acmicpc.net")) return "boj";
-        if (url.contains("programmers.co.kr")) return "programmers";
-        if (url.contains("leetcode.com")) return "leetcode";
-        if (url.contains("codeforces.com")) return "codeforces";
+        if (url.contains("acmicpc.net")) return "백준";
+        if (url.contains("programmers.co.kr")) return "프로그래머스";
+        if (url.contains("codeup.kr")) return "코드업";
+        if (url.contains("codeforces.com")) return "코드포스";
+        if (url.contains("swexpertacademy.com")) return "SW Expert Academy";
+        if (url.contains("leetcode.com")) return "리트코드";
         return "unknown";
     }
 
-    public static String extractExternalId(String url, String source) {
+    public static Long extractNumericId(String url, String source) {
         try {
             URI uri = new URI(url);
 
             switch (source) {
-                case "boj": {
-                    // https://www.acmicpc.net/problem/1000
-                    Pattern pattern = Pattern.compile("/problem/(\\d+)");
-                    Matcher matcher = pattern.matcher(uri.getPath());
-                    if (matcher.find()) return matcher.group(1);
+                case "백준": {
+                    Pattern p = Pattern.compile("/problem/(\\d+)");
+                    Matcher m = p.matcher(uri.getPath());
+                    if (m.find()) return Long.valueOf(m.group(1));
                     break;
                 }
-                case "programmers": {
-                    // https://school.programmers.co.kr/learn/courses/30/lessons/42576
-                    Pattern pattern = Pattern.compile("/lessons/(\\d+)");
-                    Matcher matcher = pattern.matcher(uri.getPath());
-                    if (matcher.find()) return matcher.group(1);
+                case "프로그래머스": {
+                    Pattern p = Pattern.compile("/lessons/(\\d+)");
+                    Matcher m = p.matcher(uri.getPath());
+                    if (m.find()) return Long.valueOf(m.group(1));
                     break;
                 }
-                case "leetcode": {
-                    // https://leetcode.com/problems/two-sum/
-                    Pattern pattern = Pattern.compile("/problems/([a-z0-9-]+)/?");
-                    Matcher matcher = pattern.matcher(uri.getPath());
-                    if (matcher.find()) return matcher.group(1);
+                case "코드업": {
+                    Pattern p = Pattern.compile("id=(\\d+)");
+                    Matcher m = p.matcher(uri.getQuery());
+                    if (m.find()) return Long.valueOf(m.group(1));
                     break;
                 }
-                case "codeforces": {
-                    // https://codeforces.com/problemset/problem/4/A
-                    Pattern pattern = Pattern.compile("/problemset/problem/(\\d+)/(\\w+)");
-                    Matcher matcher = pattern.matcher(uri.getPath());
-                    if (matcher.find()) return matcher.group(1) + matcher.group(2);
-                    break;
-                }
-                default:
-                    return "unknown";
             }
         } catch (URISyntaxException e) {
             throw new IllegalArgumentException("Invalid URL format: " + url, e);
         }
-        return "unknown";
+        return null;
+    }
+
+    public static String extractSlugId(String url, String source) {
+        try {
+            URI uri = new URI(url);
+
+            switch (source) {
+                case "리트코드": {
+                    Pattern p = Pattern.compile("/problems/([a-z0-9-]+)/?");
+                    Matcher m = p.matcher(uri.getPath());
+                    if (m.find()) return m.group(1);
+                    break;
+                }
+                case "SW Expert Academy": {
+                    Pattern p = Pattern.compile("contestProbId=([A-Za-z0-9]+)");
+                    Matcher m = p.matcher(uri.getQuery());
+                    if (m.find()) return m.group(1);
+                    break;
+                }
+                case "코드포스": {
+                    Pattern p = Pattern.compile("/problemset/problem/(\\d+)/(\\w+)");
+                    Matcher m = p.matcher(uri.getPath());
+                    if (m.find()) {
+                        return m.group(1) + m.group(2);
+                    }
+                    break;
+                }
+            }
+        } catch (URISyntaxException e) {
+            throw new IllegalArgumentException("Invalid URL format: " + url, e);
+        }
+        return null;
     }
 }

--- a/src/main/java/com/teamalgo/algo/repository/RecordRepository.java
+++ b/src/main/java/com/teamalgo/algo/repository/RecordRepository.java
@@ -2,12 +2,14 @@ package com.teamalgo.algo.repository;
 
 import com.teamalgo.algo.domain.record.Record;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+
 import java.util.List;
 import java.util.Optional;
 
-public interface RecordRepository extends JpaRepository<Record, Long> {
+public interface RecordRepository extends JpaRepository<Record, Long>, JpaSpecificationExecutor<Record> {
 
     Optional<Record> findById(Long id);
 
@@ -17,7 +19,7 @@ public interface RecordRepository extends JpaRepository<Record, Long> {
 
     Page<Record> findByUserId(Long userId, Pageable pageable);
 
-    Page<com.teamalgo.algo.domain.record.Record> findByUserIdAndIsDraftTrue(Long userId, Pageable pageable);
-
+    Page<Record> findByUserIdAndIsDraftTrue(Long userId, Pageable pageable);
 
 }
+


### PR DESCRIPTION
## 💻 작업 내용  
<!-- 이번 PR에서 작업한 내용을 간단하게 적어주세요 -->

- Record 목록 조회: Specification 기반 검색/정렬 기능 추가
- ProblemSourceDetector 수정 (사이트별 numericId/slugId 구분해서 추출)
- createdAt/updatedAt 날짜 포맷 개선 (yyyy.MM.dd HH:mm)

## ⚠️ DB 마이그레이션 
mysql에서 external_id가 numericId와 slugId로 변경되었기에 마이그레이션 필요
SHOW CREATE TABLE problem\G;   -> external_Id 유니크 인덱스 확인
(ex. UNIQUE KEY `UKg198vxhge93cokgrbvvxqf1u2` (`source`,`external_id`))
ALTER TABLE problem DROP INDEX UKg198vxhge93cokgrbvvxqf1u2; (유니크 인덱스 제거)
ALTER TABLE problem DROP COLUMN external_id; (컬럼 제거)

