### PR TITLE
[FEAT] 이미지 업로드 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,8 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	implementation 'com.google.api-client:google-api-client:1.33.2'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation 'io.awspring.cloud:spring-cloud-aws-starter:3.1.1'
+	implementation 'com.amazonaws:aws-java-sdk-s3:1.12.767'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 	compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/com/teamalgo/algo/controller/ImageController.java
+++ b/src/main/java/com/teamalgo/algo/controller/ImageController.java
@@ -1,0 +1,27 @@
+package com.teamalgo.algo.controller;
+
+import com.teamalgo.algo.dto.response.ImageUrlResponse;
+import com.teamalgo.algo.global.common.api.ApiResponse;
+import com.teamalgo.algo.global.common.code.SuccessCode;
+import com.teamalgo.algo.service.image.ImageService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/images")
+public class ImageController {
+
+    private final ImageService imageService;
+
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ApiResponse<ImageUrlResponse>> upload(@RequestPart("file") MultipartFile file) {
+        String url = imageService.uploadImage(file);
+        ImageUrlResponse response = new ImageUrlResponse(url);
+        return ApiResponse.success(SuccessCode._OK, response);
+    }
+
+}

--- a/src/main/java/com/teamalgo/algo/dto/response/ImageUrlResponse.java
+++ b/src/main/java/com/teamalgo/algo/dto/response/ImageUrlResponse.java
@@ -1,0 +1,12 @@
+package com.teamalgo.algo.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ImageUrlResponse {
+
+    private String url;
+
+}

--- a/src/main/java/com/teamalgo/algo/global/common/code/ErrorCode.java
+++ b/src/main/java/com/teamalgo/algo/global/common/code/ErrorCode.java
@@ -17,7 +17,9 @@ public enum ErrorCode implements BaseCode {
     ACCESS_DENIED(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
     OAUTH_FAILED(HttpStatus.UNAUTHORIZED, "OAuth 인증에 실패했습니다."),
     RECORD_NOT_FOUND(HttpStatus.NOT_FOUND, "기록을 찾을 수 없습니다."),
-    ALREADY_REVIEWED(HttpStatus.BAD_REQUEST, "이미 복습 완료 처리된 문제입니다.");
+    ALREADY_REVIEWED(HttpStatus.BAD_REQUEST, "이미 복습 완료 처리된 문제입니다."),
+    IMAGE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "이미지 업로드에 실패했습니다."),
+    INVALID_IMAGE_TYPE(HttpStatus.BAD_REQUEST, "허용되지 않는 이미지 형식입니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/teamalgo/algo/global/config/S3Config.java
+++ b/src/main/java/com/teamalgo/algo/global/config/S3Config.java
@@ -1,0 +1,34 @@
+package com.teamalgo.algo.global.config;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3 amazonS3() {
+        AWSCredentials basicAWSCredentials = new BasicAWSCredentials(accessKey, secretKey);
+        return AmazonS3ClientBuilder
+                .standard()
+                .withCredentials(new AWSStaticCredentialsProvider(basicAWSCredentials))
+                .withRegion(region)
+                .build();
+    }
+
+}

--- a/src/main/java/com/teamalgo/algo/service/image/ImageService.java
+++ b/src/main/java/com/teamalgo/algo/service/image/ImageService.java
@@ -1,0 +1,46 @@
+package com.teamalgo.algo.service.image;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.teamalgo.algo.global.common.code.ErrorCode;
+import com.teamalgo.algo.global.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class ImageService {
+
+    private final AmazonS3 amazonS3;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    public String uploadImage(MultipartFile file) {
+        String fileName = UUID.randomUUID() + "-" + file.getOriginalFilename();
+
+        ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentType(file.getContentType());
+        metadata.setContentLength(file.getSize());
+
+        try {
+            PutObjectRequest putObjectRequest = new PutObjectRequest(bucket, fileName, file.getInputStream(), metadata);
+
+            amazonS3.putObject(putObjectRequest);
+
+            return String.format("https://%s.s3.%s.amazonaws.com/%s", bucket, region, fileName);
+        } catch (IOException e) {
+            throw new CustomException(ErrorCode.IMAGE_UPLOAD_FAILED);
+        }
+    }
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -24,5 +24,15 @@ spring:
       port: 6379
       host: ${REDIS_HOST}
 
+cloud:
+  aws:
+    credentials:
+      access-key: ${AWS_ACCESS_KEY_ID}
+      secret-key: ${AWS_SECRET_ACCESS_KEY}
+    region:
+      static: ${AWS_REGION}
+    s3:
+      bucket: ${AWS_S3_BUCKET}
+
 kakao:
   client-id: ${KAKAO_CLIENT_ID}


### PR DESCRIPTION
## 💻 작업 내용  
- AWS S3 연동을 통한 이미지 업로드 기능 구현
- 업로드된 이미지 URL 반환 API 추가 (`POST /api/images`)

## 📌 변경 사항  
- [x] AWS S3 의존성 및 설정 추가 (`build.gradle`, `application.yml`)
- [x] S3Config 클래스 생성 및 클라이언트 Bean 등록
- [x] ErrorCode에 `IMAGE_UPLOAD_FAILED` 추가
- [x] ImageUrlResponse DTO 추가
- [x] ImageService에 업로드 로직 구현
- [x] ImageController에 업로드 API 엔드포인트 추가

## 🔗 관련 이슈  

## 📝 기타  
- 현재 버킷 정책을 통해 퍼블릭 접근 허용 중 (MVP 단계)  
- 추후에 Presigned URL 방식으로 변경 필요
