### PR TITLE
[FEAT] 문제 제목 자동 매핑 (백준 API / 프로그래머스 HTML 파싱) 및 customTitle 추가 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	implementation 'com.google.api-client:google-api-client:1.33.2'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation 'org.jsoup:jsoup:1.15.3'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 	compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/com/teamalgo/algo/controller/BookmarkController.java
+++ b/src/main/java/com/teamalgo/algo/controller/BookmarkController.java
@@ -58,13 +58,19 @@ public class BookmarkController {
     public ResponseEntity<ApiResponse<BookmarkListResponse>> getMyBookmarks(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "10") int size
+            @RequestParam(defaultValue = "10") int size,
+            @RequestParam(required = false) String category
     ) {
         User user = userDetails.getUser();
 
-        Page<RecordDTO> bookmarks = bookmarkService.getBookmarkedRecords(user, PageRequest.of(page, size));
-        BookmarkListResponse response = BookmarkListResponse.fromPage(bookmarks);
+        Page<RecordDTO> bookmarks;
+        if (category == null || category.isBlank()) {
+            bookmarks = bookmarkService.getBookmarkedRecords(user, PageRequest.of(page, size));
+        } else {
+            bookmarks = bookmarkService.getBookmarkedRecords(user, PageRequest.of(page, size), category);
+        }
 
+        BookmarkListResponse response = BookmarkListResponse.fromPage(bookmarks);
         return ApiResponse.success(SuccessCode._OK, response);
     }
 

--- a/src/main/java/com/teamalgo/algo/controller/CoreIdeaController.java
+++ b/src/main/java/com/teamalgo/algo/controller/CoreIdeaController.java
@@ -30,16 +30,23 @@ public class CoreIdeaController {
     public ResponseEntity<ApiResponse<CoreIdeaListResponse>> getMyIdeas(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "10") int size
+            @RequestParam(defaultValue = "10") int size,
+            @RequestParam(required = false) String category
     ) {
         User user = userService.findById(userDetails.getUser().getId())
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
-        Page<CoreIdeaDTO> ideas = coreIdeaService.getUserIdeas(user.getId(), PageRequest.of(page, size));
-        CoreIdeaListResponse response = CoreIdeaListResponse.fromPage(ideas);
+        Page<CoreIdeaDTO> ideas;
+        if (category == null || category.isBlank()) {
+            ideas = coreIdeaService.getUserIdeas(user.getId(), PageRequest.of(page, size));
+        } else {
+            ideas = coreIdeaService.getUserIdeas(user.getId(), PageRequest.of(page, size), category);
+        }
 
+        CoreIdeaListResponse response = CoreIdeaListResponse.fromPage(ideas);
         return ApiResponse.success(SuccessCode._OK, response);
     }
+
 
 
 }

--- a/src/main/java/com/teamalgo/algo/controller/ProblemController.java
+++ b/src/main/java/com/teamalgo/algo/controller/ProblemController.java
@@ -1,0 +1,23 @@
+package com.teamalgo.algo.controller;
+
+import com.teamalgo.algo.dto.response.ProblemPreviewResponse;
+import com.teamalgo.algo.service.problem.ProblemService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/problems")
+@RequiredArgsConstructor
+public class ProblemController {
+
+    private final ProblemService problemService;
+
+    // 문제 URL로 문제 정보 미리보기
+    @GetMapping("/fetch")
+    public ProblemPreviewResponse fetchProblem(@RequestParam String url) {
+        return problemService.fetchProblemInfo(url);
+    }
+}

--- a/src/main/java/com/teamalgo/algo/controller/RecordController.java
+++ b/src/main/java/com/teamalgo/algo/controller/RecordController.java
@@ -37,12 +37,18 @@ public class RecordController {
 
     // 목록 조회
     @GetMapping
-    public ResponseEntity<ApiResponse<RecordListResponse>> searchRecords(RecordSearchRequest request) {
-        Page<com.teamalgo.algo.domain.record.Record> records = recordService.searchRecords(request);
+    public ResponseEntity<ApiResponse<RecordListResponse>> searchRecords(
+            RecordSearchRequest request,
+            @AuthenticationPrincipal org.springframework.security.core.userdetails.UserDetails userDetails
+    ) {
+        boolean isAuthenticated = (userDetails != null);
+
+        Page<com.teamalgo.algo.domain.record.Record> records =
+                recordService.searchRecords(request, isAuthenticated);
+
         RecordListResponse response = recordService.createRecordListResponse(records);
         return ApiResponse.success(SuccessCode._OK, response);
     }
-
     // 생성
     @PostMapping
     public ResponseEntity<ApiResponse<RecordResponse.Data>> createRecord(

--- a/src/main/java/com/teamalgo/algo/domain/problem/Problem.java
+++ b/src/main/java/com/teamalgo/algo/domain/problem/Problem.java
@@ -22,19 +22,26 @@ public class Problem extends BaseEntity {
     private Long id;
 
     @Column(nullable = false)
-    private String source;
+    private String source;   // 백준, 프로그래머스 등
 
-    private Long numericId;   // BOJ, Programmers, CodeUp, Codeforces
+    private Long numericId;  // BOJ, Programmers, CodeUp, Codeforces
 
-    private String slugId;    // LeetCode 등 slug 기반
+    private String slugId;   // LeetCode 등 slug 기반
 
     @Column(nullable = false)
     private String url;
 
     @Column(nullable = false)
-    private String title;
+    private String title;    // 공식/공용 제목
 
     public String getDisplayId() {
         return numericId != null ? String.valueOf(numericId) : null;
     }
+
+    public void updateTitle(String newTitle) {
+        this.title = newTitle;
+    }
 }
+
+
+

--- a/src/main/java/com/teamalgo/algo/domain/problem/Problem.java
+++ b/src/main/java/com/teamalgo/algo/domain/problem/Problem.java
@@ -34,6 +34,7 @@ public class Problem extends BaseEntity {
     @Column(nullable = false)
     private String title;    // 공식/공용 제목
 
+    // 나중에 문제 번호 보여줄 때 사용
     public String getDisplayId() {
         return numericId != null ? String.valueOf(numericId) : null;
     }

--- a/src/main/java/com/teamalgo/algo/domain/record/Record.java
+++ b/src/main/java/com/teamalgo/algo/domain/record/Record.java
@@ -43,38 +43,46 @@ public class Record extends BaseEntity {
     @Column(name = "is_draft", nullable = false)
     private boolean isDraft;
 
+    @Column(name = "is_published", nullable = false)
+    private boolean isPublished;
+
+    // 사용자별 개별 커스텀 제목
+    private String customTitle;
+
+    // Steps
     @OneToMany(mappedBy = "record", cascade = CascadeType.ALL, orphanRemoval = true)
     @OrderBy("stepOrder ASC")
     @Fetch(FetchMode.SUBSELECT)
     @Builder.Default
     private List<RecordStep> steps = new ArrayList<>();
 
+    // Codes
     @OneToMany(mappedBy = "record", cascade = CascadeType.ALL, orphanRemoval = true)
     @OrderBy("snippetOrder ASC")
     @Fetch(FetchMode.SUBSELECT)
     @Builder.Default
     private List<RecordCode> codes = new ArrayList<>();
 
+    // Links
     @OneToMany(mappedBy = "record", cascade = CascadeType.ALL, orphanRemoval = true)
     @OrderBy("id ASC")
     @Fetch(FetchMode.SUBSELECT)
     @Builder.Default
     private List<RecordLink> links = new ArrayList<>();
 
+    // Ideas
     @OneToMany(mappedBy = "record", cascade = CascadeType.ALL, orphanRemoval = true)
     @OrderBy("id ASC")
     @Fetch(FetchMode.SUBSELECT)
     @Builder.Default
     private List<RecordCoreIdea> ideas = new ArrayList<>();
 
+    // Categories
     @OneToMany(mappedBy = "record", cascade = CascadeType.ALL, orphanRemoval = true)
     @OrderBy("id ASC")
     @Fetch(FetchMode.SUBSELECT)
     @Builder.Default
     private List<RecordCategory> recordCategories = new ArrayList<>();
-
-    @Column(name = "is_published", nullable = false)
-    private boolean isPublished;
 
     // --- 도메인 메서드 ---
     public void updateDetail(String detail) {
@@ -87,5 +95,9 @@ public class Record extends BaseEntity {
 
     public void updatePublished(boolean isPublished) {
         this.isPublished = isPublished;
+    }
+
+    public void updateCustomTitle(String customTitle) {
+        this.customTitle = customTitle;
     }
 }

--- a/src/main/java/com/teamalgo/algo/dto/ProblemDTO.java
+++ b/src/main/java/com/teamalgo/algo/dto/ProblemDTO.java
@@ -1,14 +1,23 @@
 package com.teamalgo.algo.dto;
 
+import com.teamalgo.algo.domain.problem.Problem;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 @Builder
 public class ProblemDTO {
-    private Long id;          // DB PK
-    private String source;    // 문제 출처 (백준, 리트코드 등)
-    private String displayId; // 숫자 기반 문제 번호 있으면 채움, slug 기반이면 null
-    private String url;       // 문제 URL
-    private String title;     // 문제 제목
+    private Long id;
+    private String source;
+    private String url;
+    private String title;  // API 제목
+
+    public static ProblemDTO from(Problem problem) {
+        return ProblemDTO.builder()
+                .id(problem.getId())
+                .source(problem.getSource())
+                .url(problem.getUrl())
+                .title(problem.getTitle())
+                .build();
+    }
 }

--- a/src/main/java/com/teamalgo/algo/dto/RecordDTO.java
+++ b/src/main/java/com/teamalgo/algo/dto/RecordDTO.java
@@ -1,11 +1,11 @@
 package com.teamalgo.algo.dto;
 
+import com.teamalgo.algo.domain.record.Record;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 
-import com.teamalgo.algo.domain.record.Record;
-import com.fasterxml.jackson.annotation.JsonFormat;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -14,7 +14,7 @@ import java.util.List;
 @Builder
 public class RecordDTO {
     private Long id;
-    private String title;
+    private String title;       // customTitle 우선, 없으면 problem.title
     private List<String> categories;
     private String author;
     private String source;

--- a/src/main/java/com/teamalgo/algo/dto/RecordDTO.java
+++ b/src/main/java/com/teamalgo/algo/dto/RecordDTO.java
@@ -1,4 +1,5 @@
 package com.teamalgo.algo.dto;
+
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
@@ -22,14 +23,18 @@ public class RecordDTO {
     private LocalDateTime createdAt;
 
     public static RecordDTO from(Record record) {
+        String finalTitle = (record.getCustomTitle() != null && !record.getCustomTitle().isBlank())
+                ? record.getCustomTitle()
+                : record.getProblem().getTitle();
+
         return RecordDTO.builder()
                 .id(record.getId())
-                .title(record.getProblem().getTitle())
+                .title(finalTitle)
                 .categories(record.getRecordCategories().stream()
                         .map(rc -> rc.getCategory().getName())
                         .toList())
                 .author(record.getUser().getUsername())
-                .source(record.getProblem().getSource())       // 추가
+                .source(record.getProblem().getSource())
                 .createdAt(record.getCreatedAt())
                 .build();
     }

--- a/src/main/java/com/teamalgo/algo/dto/request/RecordCreateRequest.java
+++ b/src/main/java/com/teamalgo/algo/dto/request/RecordCreateRequest.java
@@ -1,5 +1,6 @@
 package com.teamalgo.algo.dto.request;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.teamalgo.algo.dto.RecordCodeDTO;
 import com.teamalgo.algo.dto.RecordCoreIdeaDTO;
 import com.teamalgo.algo.dto.RecordLinkDTO;
@@ -41,6 +42,9 @@ public class RecordCreateRequest {
     private List<RecordCoreIdeaDTO> ideas;
     private List<RecordLinkDTO> links;
 
+    @JsonProperty("draft")
     private boolean isDraft;
+
+    @JsonProperty("published")
     private boolean isPublished;
 }

--- a/src/main/java/com/teamalgo/algo/dto/request/RecordCreateRequest.java
+++ b/src/main/java/com/teamalgo/algo/dto/request/RecordCreateRequest.java
@@ -19,8 +19,8 @@ public class RecordCreateRequest {
     @NotBlank(message = "Problem URL cannot be blank")
     private String problemUrl;
 
-    @NotBlank(message = "Problem title cannot be blank")
-    private String title;
+    @Size(max = 200, message = "Title should not exceed 200 characters")
+    private String customTitle;
 
     @NotEmpty(message = "Categories cannot be empty")
     private List<String> categories;

--- a/src/main/java/com/teamalgo/algo/dto/request/RecordUpdateRequest.java
+++ b/src/main/java/com/teamalgo/algo/dto/request/RecordUpdateRequest.java
@@ -19,8 +19,11 @@ import java.util.List;
 @Schema(description = "레코드 수정 요청 DTO (전체 교체)")
 public class RecordUpdateRequest {
 
+    @Schema(description = "사용자 커스텀 제목")
+    private String customTitle;
+
     @Size(max = 500, message = "Detail should not exceed 500 characters")
-    @Schema(description = "상세 설명", example = "알고리즘 최적화 방법을 추가로 작성했습니다.")
+    @Schema(description = "상세 설명")
     private String detail;
 
     @Schema(description = "코드 스니펫 목록")

--- a/src/main/java/com/teamalgo/algo/dto/request/RecordUpdateRequest.java
+++ b/src/main/java/com/teamalgo/algo/dto/request/RecordUpdateRequest.java
@@ -1,5 +1,6 @@
 package com.teamalgo.algo.dto.request;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.teamalgo.algo.dto.RecordCodeDTO;
 import com.teamalgo.algo.dto.RecordCoreIdeaDTO;
 import com.teamalgo.algo.dto.RecordLinkDTO;
@@ -42,10 +43,12 @@ public class RecordUpdateRequest {
     private List<String> categories;
 
     @NotNull
+    @JsonProperty("draft")
     @Schema(description = "임시 저장 여부", example = "true")
     private Boolean isDraft;
 
     @NotNull
+    @JsonProperty("published")
     @Schema(description = "공개 여부", example = "false")
     private Boolean isPublished;
 }

--- a/src/main/java/com/teamalgo/algo/dto/response/ProblemPreviewResponse.java
+++ b/src/main/java/com/teamalgo/algo/dto/response/ProblemPreviewResponse.java
@@ -1,0 +1,14 @@
+package com.teamalgo.algo.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class ProblemPreviewResponse {
+    private String title;   // API 제목
+    private String source;
+    private String url;
+}

--- a/src/main/java/com/teamalgo/algo/dto/response/RecordResponse.java
+++ b/src/main/java/com/teamalgo/algo/dto/response/RecordResponse.java
@@ -19,7 +19,8 @@ public class RecordResponse {
     public static class Data {
         private Long id;
 
-        private ProblemDTO problem;
+        private String title;
+
         private List<String> categories;
 
         private String status;

--- a/src/main/java/com/teamalgo/algo/dto/response/RecordResponse.java
+++ b/src/main/java/com/teamalgo/algo/dto/response/RecordResponse.java
@@ -20,8 +20,9 @@ public class RecordResponse {
         private Long id;
 
         private String title;
-
+        private String problemUrl;
         private List<String> categories;
+        private String source;
 
         private String status;
         private int difficulty;

--- a/src/main/java/com/teamalgo/algo/global/common/util/ProblemFetcher.java
+++ b/src/main/java/com/teamalgo/algo/global/common/util/ProblemFetcher.java
@@ -1,0 +1,45 @@
+package com.teamalgo.algo.global.common.util;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import lombok.extern.slf4j.Slf4j;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+@Slf4j
+@Service
+public class ProblemFetcher {
+
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    // 백준
+    public String fetchBaekjoonTitle(Long problemId) {
+        String url = "https://solved.ac/api/v3/problem/show?problemId=" + problemId;
+        try {
+            ResponseEntity<JsonNode> response = restTemplate.getForEntity(url, JsonNode.class);
+            if (response.getStatusCode().is2xxSuccessful()) {
+                JsonNode body = response.getBody();
+                if (body != null && body.has("titleKo")) {
+                    return body.get("titleKo").asText();
+                }
+            }
+        } catch (Exception e) {
+            log.warn("Failed to fetch Baekjoon title for problemId={}", problemId, e);
+        }
+        return null;
+    }
+
+    // 프로그래머스
+    public String fetchProgrammersTitle(String url) {
+        try {
+            Document doc = Jsoup.connect(url).get();
+            // <title>완주하지 못한 선수 | 프로그래머스 스쿨</title>
+            return doc.title().replace(" | 프로그래머스 스쿨", "").trim();
+        } catch (Exception e) {
+            log.warn("Failed to fetch Programmers title for url={}", url, e);
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/teamalgo/algo/global/common/util/ProblemSourceDetector.java
+++ b/src/main/java/com/teamalgo/algo/global/common/util/ProblemSourceDetector.java
@@ -1,5 +1,8 @@
 package com.teamalgo.algo.global.common.util;
 
+import com.teamalgo.algo.global.common.code.ErrorCode;
+import com.teamalgo.algo.global.exception.CustomException;
+
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.regex.Matcher;
@@ -42,7 +45,7 @@ public class ProblemSourceDetector {
                 }
             }
         } catch (URISyntaxException e) {
-            throw new IllegalArgumentException("Invalid URL format: " + url, e);
+            throw new CustomException(ErrorCode.INVALID_REQUEST);
         }
         return null;
     }
@@ -74,7 +77,7 @@ public class ProblemSourceDetector {
                 }
             }
         } catch (URISyntaxException e) {
-            throw new IllegalArgumentException("Invalid URL format: " + url, e);
+            throw new CustomException(ErrorCode.INVALID_REQUEST);
         }
         return null;
     }

--- a/src/main/java/com/teamalgo/algo/global/config/SecurityConfig.java
+++ b/src/main/java/com/teamalgo/algo/global/config/SecurityConfig.java
@@ -44,12 +44,13 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
                                 "/api/auth/**",
+                                "/api/records/**",
                                 "/swagger-ui/**",
                                 "/v3/api-docs/**"
                         ).permitAll()
                         .anyRequest().authenticated()
                 )
-                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider, userService), UsernamePasswordAuthenticationFilter.class);;
+                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider, userService), UsernamePasswordAuthenticationFilter.class);
         return http.build();
     }
 }

--- a/src/main/java/com/teamalgo/algo/repository/BookmarkRepository.java
+++ b/src/main/java/com/teamalgo/algo/repository/BookmarkRepository.java
@@ -19,6 +19,8 @@ public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
     Optional<Bookmark> findByUserAndRecord(User user, Record record);
     // RecordDTO 형태로 북마크 목록 반환
 
+    Page<Bookmark> findByUserAndRecord_RecordCategories_Category_Name(User user, String category, Pageable pageable);
+
     Page<Bookmark> findByUser(User user, Pageable pageable);
     List<Bookmark> findByUser(User user);
     // 사용자 별 전체 북마크 수

--- a/src/main/java/com/teamalgo/algo/repository/RecordCoreIdeaRepository.java
+++ b/src/main/java/com/teamalgo/algo/repository/RecordCoreIdeaRepository.java
@@ -15,8 +15,12 @@ public interface RecordCoreIdeaRepository extends JpaRepository<RecordCoreIdea, 
     // 특정 유저의 레코드에서 나온 아이디어 페이지네이션 조회
     Page<RecordCoreIdea> findByRecordUserId(Long userId, Pageable pageable);
 
+    Page<RecordCoreIdea> findByRecordUserIdAndRecord_RecordCategories_Category_Name(
+            Long userId, String category, Pageable pageable);
+
     // 최신순 페이지네이션 조회
     Page<RecordCoreIdea> findByRecordUserIdOrderByRecordCreatedAtDesc(Long userId, Pageable pageable);
+
 
     @Query("""
         SELECT c.name, COUNT(idea.id) as ideaCount

--- a/src/main/java/com/teamalgo/algo/service/problem/ProblemService.java
+++ b/src/main/java/com/teamalgo/algo/service/problem/ProblemService.java
@@ -1,0 +1,40 @@
+package com.teamalgo.algo.service.problem;
+
+import com.teamalgo.algo.dto.response.ProblemPreviewResponse;
+import com.teamalgo.algo.global.common.util.ProblemFetcher;
+import com.teamalgo.algo.global.common.util.ProblemSourceDetector;
+import com.teamalgo.algo.repository.ProblemRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ProblemService {
+
+    private final ProblemRepository problemRepository;
+    private final ProblemFetcher problemFetcher;
+
+    // 문제 URL을 기반으로 문제 정보를 조회 (DB 저장은 X)
+
+    public ProblemPreviewResponse fetchProblemInfo(String url) {
+        String source = ProblemSourceDetector.detectSource(url);
+
+        String title = null;
+        if ("백준".equals(source)) {
+            Long numericId = ProblemSourceDetector.extractNumericId(url, source);
+            if (numericId != null) {
+                title = problemFetcher.fetchBaekjoonTitle(numericId);
+            }
+        } else if ("프로그래머스".equals(source)) {
+            title = problemFetcher.fetchProgrammersTitle(url);
+        }
+
+        return ProblemPreviewResponse.builder()
+                .title(title)
+                .source(source)
+                .url(url)
+                .build();
+    }
+}

--- a/src/main/java/com/teamalgo/algo/service/record/BookmarkService.java
+++ b/src/main/java/com/teamalgo/algo/service/record/BookmarkService.java
@@ -52,9 +52,22 @@ public class BookmarkService {
         return bookmarkRepository.existsByUserAndRecord(user, record);
     }
 
-    // 북마크한 레코드 목록 조회
+    // 북마크한 레코드 목록 조회 (카테고리 선택 X)
     public Page<RecordDTO> getBookmarkedRecords(User user, Pageable pageable) {
-        return bookmarkRepository.findByUser(user, pageable)
+        return getBookmarkedRecords(user, pageable, null);
+    }
+
+    // 북마크한 레코드 목록 조회 (카테고리 선택 O)
+    public Page<RecordDTO> getBookmarkedRecords(User user, Pageable pageable, String category) {
+        if (category == null || category.isBlank()) {
+            return bookmarkRepository.findByUser(user, pageable)
+                    .map(bookmark -> RecordDTO.from(bookmark.getRecord()));
+        }
+
+        return bookmarkRepository.findByUserAndRecord_RecordCategories_Category_Name(
+                        user, category, pageable)
                 .map(bookmark -> RecordDTO.from(bookmark.getRecord()));
     }
+
+
 }

--- a/src/main/java/com/teamalgo/algo/service/record/CoreIdeaService.java
+++ b/src/main/java/com/teamalgo/algo/service/record/CoreIdeaService.java
@@ -16,12 +16,21 @@ import java.util.List;
 public class CoreIdeaService {
 
     private final RecordCoreIdeaRepository recordCoreIdeaRepository;
-
+    // 핵심 아이디어 목록 조회 (카테고리 선택 X)
     public Page<CoreIdeaDTO> getUserIdeas(Long userId, Pageable pageable) {
-        return recordCoreIdeaRepository.findByRecordUserId(userId, pageable)
+        return getUserIdeas(userId, pageable, null);
+    }
+    // 핵심 아이디어 목록 조회 (카테고리 선택 O)
+    public Page<CoreIdeaDTO> getUserIdeas(Long userId, Pageable pageable, String category) {
+        if (category == null || category.isBlank()) {
+            return recordCoreIdeaRepository.findByRecordUserId(userId, pageable)
+                    .map(CoreIdeaDTO::fromEntity);
+        }
+
+        return recordCoreIdeaRepository.findByRecordUserIdAndRecord_RecordCategories_Category_Name(
+                        userId, category, pageable)
                 .map(CoreIdeaDTO::fromEntity);
     }
-
     public List<CoreIdeaDTO> getRecentIdeas(Long userId, int limit) {
         Pageable pageable = PageRequest.of(0, limit);
         return recordCoreIdeaRepository.findByRecordUserIdOrderByRecordCreatedAtDesc(userId, pageable)


### PR DESCRIPTION
## 💻 작업 내용  
<!-- 이번 PR에서 작업한 내용을 간단하게 적어주세요 -->
- 백준 API / 프로그래머스 HTML 파싱을 통한 문제 title 자동 매핑
- 문제 제목 미리보기 API (/api/problem/fetch) 구현 
- 북마크 / 핵심 아이디어 목록에 category 필터링 추가 (ex. dfs, bfs)
- 로그아웃 상태에서도 기록 목록 조회 가능하도록 (필터링은 로그인 사용자만 가능)
- 모든 예외를 CustomException(ErrorCode) 기반으로 통일

## 📌 변경 사항  
<!-- 코드 변경, 기능 추가/수정, 버그 수정 등 주요 변경 사항을 기술해주세요 -->
- [x] Record 엔터티에 customTitle (사용자가 수정한 제목) 속성 추가 
-> 원래 Problem에서 기존에 저장된 title을 가져오는 형태였음. 레코드별 title을 다르게 두기 위해 해당 속성 추가, Problem 엔터티의 title에는 파싱해온 공식 제목이 들어감  (ProblemFetcher 사용시에 따로 저장됨) 