### PR TITLE
[FIX] Record 삭제 시 ReviewLog/Bookmark 삭제 누락 문제 해결

### DIFF
--- a/src/main/java/com/teamalgo/algo/domain/record/Record.java
+++ b/src/main/java/com/teamalgo/algo/domain/record/Record.java
@@ -1,7 +1,9 @@
 package com.teamalgo.algo.domain.record;
 
+import com.teamalgo.algo.domain.bookmark.Bookmark;
 import com.teamalgo.algo.domain.category.RecordCategory;
 import com.teamalgo.algo.domain.problem.Problem;
+import com.teamalgo.algo.domain.review.ReviewLog;
 import com.teamalgo.algo.domain.user.User;
 import com.teamalgo.algo.global.entity.BaseEntity;
 import jakarta.persistence.*;
@@ -83,6 +85,12 @@ public class Record extends BaseEntity {
     @Fetch(FetchMode.SUBSELECT)
     @Builder.Default
     private List<RecordCategory> recordCategories = new ArrayList<>();
+
+    @OneToMany(mappedBy = "record", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ReviewLog> reviewLogs = new ArrayList<>();
+
+    @OneToMany(mappedBy = "record", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Bookmark> bookmarks = new ArrayList<>();
 
     // --- 도메인 메서드 ---
     public void updateDetail(String detail) {


### PR DESCRIPTION
## 💻 작업 내용
- Record 엔티티에 ReviewLog, Bookmark 매핑 추가
- Record 삭제 시 연관된 ReviewLog, Bookmark가 먼저 삭제되도록 cascade 및 orphanRemoval 적용
- Record 삭제가 보장됨에 따라 User 삭제 시 발생하던 FK 제약 오류(`record_id cannot be null`)도 함께 해결됨

## 📌 변경 사항
- Record.java
  - `List<ReviewLog> reviewLogs` 추가
  - `List<Bookmark> bookmarks` 추가

## 🔗 관련 이슈

## 📝 기타
- 원래는 User 삭제 과정에서 발견된 문제였으나, 근본 원인은 Record 삭제 시 연관 데이터 삭제가 누락된 것이었음
- 이 변경으로 User 삭제, Record 단독 삭제 모두 정상 동작
