### PR TITLE
[FEAT] 레코드/북마크/아이디어 조회 정책 개선 (draft·비공개 처리)

### DIFF
--- a/src/main/java/com/teamalgo/algo/controller/RecordController.java
+++ b/src/main/java/com/teamalgo/algo/controller/RecordController.java
@@ -30,7 +30,7 @@ public class RecordController {
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
         User user = userDetails.getUser();
-        var record = recordService.getRecordById(id);
+        var record = recordService.getRecordById(id, user);
         var response = recordService.createRecordResponse(record, user);
         return ApiResponse.success(SuccessCode._OK, response);
     }

--- a/src/main/java/com/teamalgo/algo/repository/BookmarkRepository.java
+++ b/src/main/java/com/teamalgo/algo/repository/BookmarkRepository.java
@@ -13,20 +13,32 @@ import java.util.List;
 import java.util.Optional;
 
 public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
+
     // 단일 조회에서 북마크 여부 확인할 때
-    boolean existsByUserAndRecord(User user, Record record);
+    boolean existsByUserAndRecordAndRecordIsDraftFalse(User user, Record record);
+
     // 북마크 엔터티 가져와서 삭제할 때
-    Optional<Bookmark> findByUserAndRecord(User user, Record record);
-    // RecordDTO 형태로 북마크 목록 반환
+    Optional<Bookmark> findByUserAndRecordAndRecordIsDraftFalse(User user, Record record);
 
-    Page<Bookmark> findByUserAndRecord_RecordCategories_Category_Name(User user, String category, Pageable pageable);
+    // 카테고리별 북마크 목록
+    Page<Bookmark> findByUserAndRecordIsDraftFalseAndRecord_RecordCategories_Category_Name(
+            User user, String category, Pageable pageable);
 
-    Page<Bookmark> findByUser(User user, Pageable pageable);
-    List<Bookmark> findByUser(User user);
+    // 전체 북마크 목록
+    Page<Bookmark> findByUserAndRecordIsDraftFalse(User user, Pageable pageable);
+
+
     // 사용자 별 전체 북마크 수
-    Long countByUser(User user);
-    // 사용자 별 최근 1주일 북마크 수
-    @Query("SELECT COUNT(b) FROM Bookmark b WHERE b.user = :user AND b.createdAt >= :startDate")
-    Long countThisWeekByUser(@Param("user") User user, @Param("startDate") LocalDateTime startDate);
+    @Query("SELECT COUNT(b) FROM Bookmark b WHERE b.user = :user AND b.record.isDraft = false")
+    Long countByUser(@Param("user") User user);
 
+    // 최근 1주일 북마크 수
+    @Query("""
+        SELECT COUNT(b) FROM Bookmark b 
+        WHERE b.user = :user 
+          AND b.record.isDraft = false 
+          AND b.createdAt >= :startDate
+    """)
+    Long countThisWeekByUser(@Param("user") User user, @Param("startDate") LocalDateTime startDate);
 }
+

--- a/src/main/java/com/teamalgo/algo/repository/RecordCoreIdeaRepository.java
+++ b/src/main/java/com/teamalgo/algo/repository/RecordCoreIdeaRepository.java
@@ -12,15 +12,16 @@ import java.util.List;
 
 public interface RecordCoreIdeaRepository extends JpaRepository<RecordCoreIdea, Long> {
 
-    // 특정 유저의 레코드에서 나온 아이디어 페이지네이션 조회
-    Page<RecordCoreIdea> findByRecordUserId(Long userId, Pageable pageable);
+    // 특정 유저의 레코드에서 나온 아이디어 (draft 제외)
+    Page<RecordCoreIdea> findByRecordUserIdAndRecordIsDraftFalse(Long userId, Pageable pageable);
 
-    Page<RecordCoreIdea> findByRecordUserIdAndRecord_RecordCategories_Category_Name(
+    // 특정 카테고리 + draft 제외
+    Page<RecordCoreIdea> findByRecordUserIdAndRecordIsDraftFalseAndRecord_RecordCategories_Category_Name(
             Long userId, String category, Pageable pageable);
 
-    // 최신순 페이지네이션 조회
-    Page<RecordCoreIdea> findByRecordUserIdOrderByRecordCreatedAtDesc(Long userId, Pageable pageable);
-
+    // 최신순 + draft 제외
+    Page<RecordCoreIdea> findByRecordUserIdAndRecordIsDraftFalseOrderByRecordCreatedAtDesc(
+            Long userId, Pageable pageable);
 
     @Query("""
         SELECT c.name, COUNT(idea.id) as ideaCount
@@ -29,13 +30,12 @@ public interface RecordCoreIdeaRepository extends JpaRepository<RecordCoreIdea, 
         JOIN RecordCategory rc ON rc.record = r
         JOIN rc.category c
         WHERE r.user = :user
+        AND r.isDraft = false
         GROUP BY c.name
         ORDER BY ideaCount DESC
     """)
     List<Object[]> findTopCategoryByUser(@Param("user") User user, Pageable pageable);
 
-    // 사용자 별 작성한 핵심 아이디어 개수
-    @Query("SELECT COUNT(idea) FROM RecordCoreIdea idea WHERE idea.record.user = :user")
+    @Query("SELECT COUNT(idea) FROM RecordCoreIdea idea WHERE idea.record.user = :user AND idea.record.isDraft = false")
     Long countByUser(@Param("user") User user);
-
 }

--- a/src/main/java/com/teamalgo/algo/repository/RecordRepository.java
+++ b/src/main/java/com/teamalgo/algo/repository/RecordRepository.java
@@ -12,14 +12,10 @@ import java.util.Optional;
 public interface RecordRepository extends JpaRepository<Record, Long>, JpaSpecificationExecutor<Record> {
 
     Optional<Record> findById(Long id);
-
+    Optional<Record> findByIdAndIsDraftFalse(Long id);
     List<Record> findByUserId(Long userId);
-
-    Optional<Record> findByIdAndUserId(Long recordId, Long userID);
-
-    Page<Record> findByUserId(Long userId, Pageable pageable);
-
+    Page<Record> findByUserIdAndIsDraftFalse(Long userId, Pageable pageable);
     Page<Record> findByUserIdAndIsDraftTrue(Long userId, Pageable pageable);
+    Optional<Record> findByIdAndUserId(Long recordId, Long userId);
 
 }
-

--- a/src/main/java/com/teamalgo/algo/service/record/CoreIdeaService.java
+++ b/src/main/java/com/teamalgo/algo/service/record/CoreIdeaService.java
@@ -16,28 +16,35 @@ import java.util.List;
 public class CoreIdeaService {
 
     private final RecordCoreIdeaRepository recordCoreIdeaRepository;
+
     // 핵심 아이디어 목록 조회 (카테고리 선택 X)
     public Page<CoreIdeaDTO> getUserIdeas(Long userId, Pageable pageable) {
-        return getUserIdeas(userId, pageable, null);
+        return recordCoreIdeaRepository.findByRecordUserIdAndRecordIsDraftFalse(userId, pageable)
+                .map(CoreIdeaDTO::fromEntity);
     }
+
     // 핵심 아이디어 목록 조회 (카테고리 선택 O)
     public Page<CoreIdeaDTO> getUserIdeas(Long userId, Pageable pageable, String category) {
         if (category == null || category.isBlank()) {
-            return recordCoreIdeaRepository.findByRecordUserId(userId, pageable)
+            return recordCoreIdeaRepository.findByRecordUserIdAndRecordIsDraftFalse(userId, pageable)
                     .map(CoreIdeaDTO::fromEntity);
         }
 
-        return recordCoreIdeaRepository.findByRecordUserIdAndRecord_RecordCategories_Category_Name(
+        return recordCoreIdeaRepository
+                .findByRecordUserIdAndRecordIsDraftFalseAndRecord_RecordCategories_Category_Name(
                         userId, category, pageable)
                 .map(CoreIdeaDTO::fromEntity);
     }
+
+    // 최신 아이디어 조회 (draft 제외)
     public List<CoreIdeaDTO> getRecentIdeas(Long userId, int limit) {
         Pageable pageable = PageRequest.of(0, limit);
-        return recordCoreIdeaRepository.findByRecordUserIdOrderByRecordCreatedAtDesc(userId, pageable)
+        return recordCoreIdeaRepository
+                .findByRecordUserIdAndRecordIsDraftFalseOrderByRecordCreatedAtDesc(userId, pageable)
                 .stream()
                 .map(CoreIdeaDTO::fromEntity)
                 .toList();
     }
-
 }
+
 


### PR DESCRIPTION
## 💻 작업 내용  
<!-- 이번 PR에서 작업한 내용을 간단하게 적어주세요 -->

- 레코드/북마크/핵심 아이디어 조회 시 draft, 비공개 처리 로직 적용

## 📌 변경 사항  
<!-- 코드 변경, 기능 추가/수정, 버그 수정 등 주요 변경 사항을 기술해주세요 -->

- [x] 전체 목록 조회(/records) → isDraft=false && isPublished=true 조건으로 **공개글만 노출**
- [x]  내 기록 목록 조회(/my/records) → isDraft=false 조건으로 내 공개글 + 내 비공개글 조회 **(draft 제외)**
- [x]  단일 조회(getRecordById) → 공개글은 누구나 조회 가능, 비공개/임시저장글은 작성자만 조회 가능
- [x]  북마크 기능 수정 → **공개글만 북마크 가능**하도록 제한 (isDraft=false && isPublished=true)
- [x]  핵심 아이디어 조회 수정 → draft 에 속한 아이디어는 조회되지 않도록 필터링