### PR TITLE
[FIX] Record 삭제 시 StatsDaily & 스트릭 동기화 처리

### DIFF
--- a/src/main/java/com/teamalgo/algo/domain/user/User.java
+++ b/src/main/java/com/teamalgo/algo/domain/user/User.java
@@ -54,6 +54,12 @@ public class User extends BaseEntity {
     @Column
     private LocalDate lastRecordedDate; // 마지막 기록한 날짜
 
+    // 최장 스트릭 기간
+    @Column
+    private LocalDate maxStreakStartDate;
+    @Column
+    private LocalDate maxStreakEndDate;
+
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Record> records = new ArrayList<>();
 

--- a/src/main/java/com/teamalgo/algo/repository/StatsDailyRepository.java
+++ b/src/main/java/com/teamalgo/algo/repository/StatsDailyRepository.java
@@ -27,4 +27,6 @@ public interface StatsDailyRepository extends JpaRepository<StatsDaily, Long> {
     @Query("SELECT SUM(s.successCnt), SUM(s.failCnt) FROM StatsDaily s WHERE s.user = :user")
     Object getSuccessAndFail(@Param("user") User user);
 
+    List<StatsDaily> findByUserOrderByStatDateAsc(User user);
+
 }

--- a/src/main/java/com/teamalgo/algo/service/record/RecordService.java
+++ b/src/main/java/com/teamalgo/algo/service/record/RecordService.java
@@ -25,19 +25,23 @@ import com.teamalgo.algo.repository.ProblemRepository;
 import com.teamalgo.algo.repository.CategoryRepository;
 import com.teamalgo.algo.service.problem.ProblemService;
 import com.teamalgo.algo.service.stats.StatsService;
-import com.teamalgo.algo.service.record.BookmarkService;
 import com.teamalgo.algo.global.common.util.ProblemSourceDetector;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
 import jakarta.persistence.criteria.Join;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.*;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -49,6 +53,9 @@ public class RecordService {
     private final BookmarkService bookmarkService;
     private final StatsService statsService;
     private final ProblemService problemService;
+
+    @PersistenceContext
+    private EntityManager entityManager;
 
     // 레코드 생성
     @Transactional
@@ -143,7 +150,7 @@ public class RecordService {
         }
 
         boolean isSuccess = record.getStatus().equals("success");
-        statsService.updateStats(user, isSuccess);
+        statsService.increaseStats(user, isSuccess);
 
         return recordRepository.save(record);
     }
@@ -301,6 +308,11 @@ public class RecordService {
             throw new CustomException(ErrorCode.ACCESS_DENIED);
         }
         recordRepository.delete(record);
+
+        // 통계 반영
+        LocalDate date = record.getCreatedAt().toLocalDate();
+        boolean isSuccess = record.getStatus().equals("success");
+        statsService.decreaseStats(user, date, isSuccess);
     }
 
     // 단건 응답 변환


### PR DESCRIPTION
## 💻 작업 내용
- Record 삭제 시 StatsDaily 및 Streak 갱신 로직 추가

## 📌 변경 사항
- record 삭제 시 StatsDaily 카운트 감소 및 row 삭제 처리
- 해당 날짜의 모든 기록이 삭제된 경우, streak에 영향이 있는 경우에만 재계산 수행
- currentStreak 보정 로직 추가 (오늘/어제 기록 없는 경우 0으로 초기화)

## 🔗 관련 이슈

## 📝 기타
