### PR TITLE
[REFACTOR] mostSolvedCategory 조회 정렬 기준 개선

### DIFF
--- a/src/main/java/com/teamalgo/algo/repository/RecordCategoryRepository.java
+++ b/src/main/java/com/teamalgo/algo/repository/RecordCategoryRepository.java
@@ -13,14 +13,14 @@ import java.util.List;
 public interface RecordCategoryRepository extends JpaRepository<RecordCategory, Long> {
 
     @Query("""
-        SELECT c.name, COUNT(r.id) as solvedCount
-        FROM RecordCategory rc
-        JOIN rc.record r
-        JOIN rc.category c
-        WHERE r.user = :user
-        GROUP BY c.name
-        ORDER BY solvedCount DESC
-    """)
+    SELECT c.name, COUNT(r.id) as solvedCount, MAX(r.createdAt) as lastSolvedDate
+    FROM RecordCategory rc
+    JOIN rc.record r
+    JOIN rc.category c
+    WHERE r.user = :user
+    GROUP BY c.name
+    ORDER BY solvedCount DESC, lastSolvedDate DESC
+""")
     List<Object[]> findMostSolvedByUser(@Param("user") User user, Pageable pageable);
 
     @Query("SELECT new com.teamalgo.algo.dto.response.CategoryStatsResponse(c.slug, c.name, COUNT(rc)) " +


### PR DESCRIPTION
## 💻 작업 내용
- `findMostSolvedByUser` 쿼리 정렬 기준 보완
- `solvedCount`가 동일한 경우 최근에 등록한 기록의 카테고리가 조회되도록 개선

## 📌 변경 사항
- `RecordCategoryRepository`의 `findMostSolvedByUser` JPQL 쿼리 수정

## 🔗 관련 이슈

## 📝 기타
