### PR TITLE
[FEAT] 북마크 페이지네이션 수정 & 인기순 정렬 로직 추가 & detail 길이 제약 해제

### DIFF
--- a/src/main/java/com/teamalgo/algo/controller/BookmarkController.java
+++ b/src/main/java/com/teamalgo/algo/controller/BookmarkController.java
@@ -57,17 +57,20 @@ public class BookmarkController {
     @GetMapping
     public ResponseEntity<ApiResponse<BookmarkListResponse>> getMyBookmarks(
             @AuthenticationPrincipal CustomUserDetails userDetails,
-            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "1") int page,
             @RequestParam(defaultValue = "10") int size,
             @RequestParam(required = false) String category
     ) {
         User user = userDetails.getUser();
 
+        int pageIndex = (page > 0) ? page - 1 : 0;
+        Pageable pageable = PageRequest.of(pageIndex, size);
+
         Page<RecordDTO> bookmarks;
         if (category == null || category.isBlank()) {
-            bookmarks = bookmarkService.getBookmarkedRecords(user, PageRequest.of(page, size));
+            bookmarks = bookmarkService.getBookmarkedRecords(user, pageable);
         } else {
-            bookmarks = bookmarkService.getBookmarkedRecords(user, PageRequest.of(page, size), category);
+            bookmarks = bookmarkService.getBookmarkedRecords(user, pageable, category);
         }
 
         BookmarkListResponse response = BookmarkListResponse.fromPage(bookmarks);

--- a/src/main/java/com/teamalgo/algo/dto/request/RecordUpdateRequest.java
+++ b/src/main/java/com/teamalgo/algo/dto/request/RecordUpdateRequest.java
@@ -23,7 +23,6 @@ public class RecordUpdateRequest {
     @Schema(description = "사용자 커스텀 제목")
     private String customTitle;
 
-    @Size(max = 500, message = "Detail should not exceed 500 characters")
     @Schema(description = "상세 설명")
     private String detail;
 

--- a/src/main/java/com/teamalgo/algo/service/record/RecordService.java
+++ b/src/main/java/com/teamalgo/algo/service/record/RecordService.java
@@ -172,6 +172,20 @@ public class RecordService {
             RecordSearchRequest req,
             boolean isAuthenticated
     ) {
+        if (req.getSort() == RecordSearchRequest.SortType.POPULAR) {
+            LocalDateTime start = req.getStartDate() != null ? req.getStartDate().atStartOfDay() : null;
+            LocalDateTime end = req.getEndDate() != null ? req.getEndDate().plusDays(1).atStartOfDay().minusNanos(1) : null;
+
+            return recordRepository.findPopularWithFilters(
+                    (req.getSearch() != null && !req.getSearch().isBlank()) ? "%" + req.getSearch() + "%" : null,
+                    (req.getAuthor() != null && !req.getAuthor().isBlank()) ? req.getAuthor() : null,
+                    (req.getCategory() != null && !req.getCategory().isBlank()) ? req.getCategory() : null,
+                    start,
+                    end,
+                    PageRequest.of(req.getPageIndex(), req.getSize())
+            );
+        }
+
         Sort sort = (req.getSort() == RecordSearchRequest.SortType.LATEST)
                 ? Sort.by(Sort.Direction.DESC, "createdAt")
                 : Sort.by(Sort.Direction.DESC, "id");


### PR DESCRIPTION
## 💻 작업 내용  
<!-- 이번 PR에서 작업한 내용을 간단하게 적어주세요 -->
- 북마크 조회 API에 1-based 페이지네이션 적용
- 레코드 인기순(POPULAR) 정렬 로직 추가 
 (최근 1주 북마크 수 기준, 동률일 경우 detail 길이 긴 순서 우선)
- 레코드 수정 시 detail에 걸려있던 500자 제한 해제

