### PR TITLE
[FIX] 임시저장 검증 로직 수정 및 에러 메시지 세분화

### DIFF
--- a/src/main/java/com/teamalgo/algo/dto/RecordCodeDTO.java
+++ b/src/main/java/com/teamalgo/algo/dto/RecordCodeDTO.java
@@ -22,17 +22,10 @@ import com.teamalgo.algo.domain.record.Record;
 public class RecordCodeDTO {
     private Long id; // Create 시 null, Update/Response 시 존재
 
-    @NotBlank(message = "Code cannot be blank")
     private String code;
-
-    @NotBlank(message = "Language cannot be blank")
     private String language;
-
-    @NotBlank(message = "Verdict cannot be blank")
-    @Pattern(regexp = "pass|fail", message = "Verdict must be 'pass' or 'fail'")
     private String verdict;
 
-    @Min(value = 0, message = "Snippet order must be 0 or greater")
     private int snippetOrder;
 
     public RecordCode toEntity(Record record) {

--- a/src/main/java/com/teamalgo/algo/dto/RecordStepDTO.java
+++ b/src/main/java/com/teamalgo/algo/dto/RecordStepDTO.java
@@ -14,7 +14,6 @@ public class RecordStepDTO {
     private Long id;       // update/삭제 시 필요
     private int stepOrder; // 단계 순서
 
-    @NotBlank(message = "Step text cannot be blank")
     private String text;
 
     public RecordStep toEntity(Record record) {

--- a/src/main/java/com/teamalgo/algo/dto/request/RecordCreateRequest.java
+++ b/src/main/java/com/teamalgo/algo/dto/request/RecordCreateRequest.java
@@ -24,27 +24,12 @@ public class RecordCreateRequest {
     @Size(max = 200, message = "Title should not exceed 200 characters")
     private String customTitle;
 
-    @NotEmpty(message = "Categories cannot be empty")
     private List<String> categories;
-
-    @NotNull(message = "Status cannot be null")
-    @Pattern(regexp = "success|fail", message = "Status must be 'success' or 'fail'")
     private String status;
-
-    @Min(value = 1, message = "Difficulty must be between 1 and 5")
-    @Max(value = 5, message = "Difficulty must be between 1 and 5")
-    private int difficulty;
-
-    @NotBlank(message = "Detail cannot be blank")
-    @Size(max = 2000, message = "Detail should not exceed 2000 characters")
+    private Integer difficulty;
     private String detail;
 
-    @NotNull(message = "At least one code is required")
-    @Size(min = 1, message = "At least one code is required")
     private List<@Valid RecordCodeDTO> codes;
-
-    @NotNull(message = "At least one step is required")
-    @Size(min = 1, message = "At least one step is required")
     private List<@Valid RecordStepDTO> steps;
 
     private List<RecordCoreIdeaDTO> ideas;

--- a/src/main/java/com/teamalgo/algo/dto/request/RecordUpdateRequest.java
+++ b/src/main/java/com/teamalgo/algo/dto/request/RecordUpdateRequest.java
@@ -6,8 +6,7 @@ import com.teamalgo.algo.dto.RecordCoreIdeaDTO;
 import com.teamalgo.algo.dto.RecordLinkDTO;
 import com.teamalgo.algo.dto.RecordStepDTO;
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
+import jakarta.validation.constraints.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
@@ -26,11 +25,9 @@ public class RecordUpdateRequest {
     @Schema(description = "상세 설명")
     private String detail;
 
-    @Size(min = 1, message = "At least one code is required if provided")
     @Schema(description = "코드 스니펫 목록")
     private List<RecordCodeDTO> codes;
 
-    @Size(min = 1, message = "At least one step is required if provided")
     @Schema(description = "풀이 단계 목록")
     private List<RecordStepDTO> steps;
 
@@ -42,6 +39,9 @@ public class RecordUpdateRequest {
 
     @Schema(description = "카테고리 목록", example = "[\"DP\", \"Graph\"]")
     private List<String> categories;
+
+    private String status;
+    private Integer difficulty;
 
     @JsonProperty("draft")
     @Schema(description = "임시 저장 여부", example = "true")

--- a/src/main/java/com/teamalgo/algo/global/common/code/ErrorCode.java
+++ b/src/main/java/com/teamalgo/algo/global/common/code/ErrorCode.java
@@ -19,7 +19,15 @@ public enum ErrorCode implements BaseCode {
     RECORD_NOT_FOUND(HttpStatus.NOT_FOUND, "기록을 찾을 수 없습니다."),
     ALREADY_REVIEWED(HttpStatus.BAD_REQUEST, "이미 복습 완료 처리된 문제입니다."),
     IMAGE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "이미지 업로드에 실패했습니다."),
-    INVALID_IMAGE_TYPE(HttpStatus.BAD_REQUEST, "허용되지 않는 이미지 형식입니다.");
+    INVALID_IMAGE_TYPE(HttpStatus.BAD_REQUEST, "허용되지 않는 이미지 형식입니다."),
+
+    // 레코드 발행 시 에러
+    INVALID_STATUS(HttpStatus.BAD_REQUEST, "Status 값은 success 또는 fail 이어야 합니다."),
+    INVALID_DIFFICULTY(HttpStatus.BAD_REQUEST, "난이도는 1~5 사이여야 합니다."),
+    INVALID_CODES(HttpStatus.BAD_REQUEST, "코드는 최소 1개 이상 필요합니다."),
+    INVALID_STEPS(HttpStatus.BAD_REQUEST, "풀이 단계는 최소 1개 이상 필요합니다."),
+    INVALID_CATEGORIES(HttpStatus.BAD_REQUEST, "카테고리는 최소 1개 이상 필요합니다."),
+    INVALID_DETAIL(HttpStatus.BAD_REQUEST, "상세 설명은 비워둘 수 없습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/teamalgo/algo/service/record/RecordService.java
+++ b/src/main/java/com/teamalgo/algo/service/record/RecordService.java
@@ -60,6 +60,29 @@ public class RecordService {
     // 레코드 생성
     @Transactional
     public com.teamalgo.algo.domain.record.Record createRecord(User user, RecordCreateRequest req) {
+
+        if (!req.isDraft()) {
+            if (req.getDetail() == null || req.getDetail().isBlank()) {
+                throw new CustomException(ErrorCode.INVALID_DETAIL);
+            }
+            if (req.getCategories() == null || req.getCategories().isEmpty()) {
+                throw new CustomException(ErrorCode.INVALID_CATEGORIES);
+            }
+            if (req.getStatus() == null ||
+                    (!req.getStatus().equals("success") && !req.getStatus().equals("fail"))) {
+                throw new CustomException(ErrorCode.INVALID_STATUS);
+            }
+            if (req.getDifficulty() == null || req.getDifficulty() < 1 || req.getDifficulty() > 5) {
+                throw new CustomException(ErrorCode.INVALID_DIFFICULTY);
+            }
+            if (req.getCodes() == null || req.getCodes().isEmpty()) {
+                throw new CustomException(ErrorCode.INVALID_CODES);
+            }
+            if (req.getSteps() == null || req.getSteps().isEmpty()) {
+                throw new CustomException(ErrorCode.INVALID_STEPS);
+            }
+        }
+
         Problem problem = problemRepository.findByUrl(req.getProblemUrl())
                 .orElseGet(() -> {
                     ProblemPreviewResponse preview = problemService.fetchProblemInfo(req.getProblemUrl());
@@ -155,7 +178,7 @@ public class RecordService {
             record.getRecordCategories().addAll(recordCategories);
         }
 
-        boolean isSuccess = record.getStatus().equals("success");
+        boolean isSuccess = "success".equals(record.getStatus());
 
         // 임시 저장 아닐때만 통계 반영
         if (!record.isDraft()) {
@@ -291,6 +314,29 @@ public class RecordService {
             throw new CustomException(ErrorCode.ACCESS_DENIED);
         }
 
+        boolean isDraft = (req.getIsDraft() != null && req.getIsDraft());
+
+        if (!isDraft) {
+            if (req.getDetail() == null || req.getDetail().isBlank()) {
+                throw new CustomException(ErrorCode.INVALID_DETAIL);
+            }
+            if (req.getCategories() == null || req.getCategories().isEmpty()) {
+                throw new CustomException(ErrorCode.INVALID_CATEGORIES);
+            }
+            if (req.getStatus() == null ||
+                    (!req.getStatus().equals("success") && !req.getStatus().equals("fail"))) {
+                throw new CustomException(ErrorCode.INVALID_STATUS);
+            }
+            if (req.getDifficulty() == null || req.getDifficulty() < 1 || req.getDifficulty() > 5) {
+                throw new CustomException(ErrorCode.INVALID_DIFFICULTY);
+            }
+            if (req.getCodes() == null || req.getCodes().isEmpty()) {
+                throw new CustomException(ErrorCode.INVALID_CODES);
+            }
+            if (req.getSteps() == null || req.getSteps().isEmpty()) {
+                throw new CustomException(ErrorCode.INVALID_STEPS);
+            }
+        }
 
         boolean prevDraft = record.isDraft();
 
@@ -317,7 +363,7 @@ public class RecordService {
         // Codes
         if (req.getCodes() != null) {
             if (req.getCodes().isEmpty()) {
-                throw new CustomException(ErrorCode.INVALID_REQUEST);
+                throw new CustomException(ErrorCode.INVALID_CODES);
             }
             record.getCodes().clear();
             recordRepository.flush();
@@ -332,7 +378,7 @@ public class RecordService {
         // Steps
         if (req.getSteps() != null) {
             if (req.getSteps().isEmpty()) {
-                throw new CustomException(ErrorCode.INVALID_REQUEST);
+                throw new CustomException(ErrorCode.INVALID_STEPS);
             }
             record.getSteps().clear();
             recordRepository.flush();
@@ -391,7 +437,7 @@ public class RecordService {
 
         // 임시저장 -> 발행으로 전환된 경우 통계 반영
         if (prevDraft && !record.isDraft()) {
-            boolean isSuccess = record.getStatus().equals("success");
+            boolean isSuccess = "success".equals(record.getStatus());
             statsService.increaseStats(user, isSuccess);
         }
 
@@ -414,7 +460,7 @@ public class RecordService {
         if (!record.isDraft()) {
             // 통계 반영
             LocalDate date = record.getCreatedAt().toLocalDate();
-            boolean isSuccess = record.getStatus().equals("success");
+            boolean isSuccess = "success".equals(record.getStatus());
             statsService.decreaseStats(user, date, isSuccess);
         }
     }


### PR DESCRIPTION
## 💻 작업 내용  
<!-- 이번 PR에서 작업한 내용을 간단하게 적어주세요 -->

- 임시저장 시 필수값 최소화 로직 보완 (문제 URL만 필수 입력)
- 레코드 관련 에러 메시지 세분화 (dto에서 에러 코드로 이동, 원래 dto에서 관리하였으나 임시저장 관련해서 필수값이 달라지게 되면서 서비스쪽에서 에러코드로 처리하게끔 수정하였음)

## 📝 기타  
<!-- 특이사항, 참고할 점, 리뷰어에게 전달할 내용 등이 있다면 작성해주세요 -->

- [x] DB 마이그레이션 필요 (임시저장 필수값 최소화 과정에서)

-- record.status를 NULL 허용으로 변경
ALTER TABLE record
    MODIFY status varchar(255) COLLATE utf8mb4_unicode_ci NULL;

-- record_code 필드들을 NULL 허용으로 변경
ALTER TABLE record_code
    MODIFY code text COLLATE utf8mb4_unicode_ci NULL,
    MODIFY language varchar(255) COLLATE utf8mb4_unicode_ci NULL,
    MODIFY verdict varchar(255) COLLATE utf8mb4_unicode_ci NULL;

-- record_step.text를 NULL 허용으로 변경
ALTER TABLE record_step
    MODIFY text text COLLATE utf8mb4_unicode_ci NULL;