### PR TITLE
[REFACTOR] 컬럼 매핑을 TEXT 타입으로 변경

### DIFF
--- a/src/main/java/com/teamalgo/algo/domain/record/Record.java
+++ b/src/main/java/com/teamalgo/algo/domain/record/Record.java
@@ -39,7 +39,7 @@ public class Record extends BaseEntity {
 
     private Integer difficulty;
 
-    @Lob
+    @Column(columnDefinition = "TEXT")
     private String detail;
 
     @Column(name = "is_draft", nullable = false)

--- a/src/main/java/com/teamalgo/algo/domain/record/RecordCode.java
+++ b/src/main/java/com/teamalgo/algo/domain/record/RecordCode.java
@@ -24,8 +24,7 @@ public class RecordCode {
     @Column(nullable = false)
     private String language;
 
-    @Lob
-    @Column(nullable = false)
+    @Column(columnDefinition = "TEXT", nullable = false)
     private String code;
 
     @Column(nullable = false)

--- a/src/main/java/com/teamalgo/algo/domain/record/RecordCoreIdea.java
+++ b/src/main/java/com/teamalgo/algo/domain/record/RecordCoreIdea.java
@@ -19,8 +19,7 @@ public class RecordCoreIdea {
     @JoinColumn(name = "record_id")
     private Record record;
 
-    @Lob
-    @Column(nullable = true)
+    @Column(columnDefinition = "TEXT", nullable = true)
     private String content;
 
     public void update(String content) {

--- a/src/main/java/com/teamalgo/algo/domain/record/RecordStep.java
+++ b/src/main/java/com/teamalgo/algo/domain/record/RecordStep.java
@@ -25,8 +25,7 @@ public class RecordStep {
     @Column(nullable = false)
     private int stepOrder;
 
-    @Lob
-    @Column(nullable = false)
+    @Column(columnDefinition = "TEXT", nullable = false)
     private String text;
 
     public void update(int stepOrder, String text) {


### PR DESCRIPTION
## 💻 작업 내용  
<!-- 이번 PR에서 작업한 내용을 간단하게 적어주세요 -->
- Hibernate DDL-auto 시 tinytext로 생성되던 문제 해결

## 📌 변경 사항  
<!-- 코드 변경, 기능 추가/수정, 버그 수정 등 주요 변경 사항을 기술해주세요 -->
- record, record_code, record_step, record_core_idea 엔티티 컬럼 수정
  - 컬럼 타입을 TEXT로 명시하여 매핑 방식 통일

## 🔗 관련 이슈  
<!-- 연결된 이슈 번호를 적어주세요 (ex. #123) -->

## 📝 기타  
<!-- 특이사항, 참고할 점, 리뷰어에게 전달할 내용 등이 있다면 작성해주세요 -->
마이그레이션 SQL
```sql
ALTER TABLE record MODIFY detail text;
ALTER TABLE record_code MODIFY code text;
ALTER TABLE record_step MODIFY text text;
ALTER TABLE record_core_idea MODIFY content text;
