### PR TITLE
[FIX] 이미지 업로드 500 에러 수정

### DIFF
--- a/src/main/java/com/teamalgo/algo/global/common/code/ErrorCode.java
+++ b/src/main/java/com/teamalgo/algo/global/common/code/ErrorCode.java
@@ -27,7 +27,8 @@ public enum ErrorCode implements BaseCode {
     INVALID_CODES(HttpStatus.BAD_REQUEST, "코드는 최소 1개 이상 필요합니다."),
     INVALID_STEPS(HttpStatus.BAD_REQUEST, "풀이 단계는 최소 1개 이상 필요합니다."),
     INVALID_CATEGORIES(HttpStatus.BAD_REQUEST, "카테고리는 최소 1개 이상 필요합니다."),
-    INVALID_DETAIL(HttpStatus.BAD_REQUEST, "상세 설명은 비워둘 수 없습니다.");
+    INVALID_DETAIL(HttpStatus.BAD_REQUEST, "상세 설명은 비워둘 수 없습니다."),
+    INVALID_FILE_TYPE(HttpStatus.BAD_REQUEST, "허용되지 않은 이미지 형식입니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/teamalgo/algo/service/image/ImageService.java
+++ b/src/main/java/com/teamalgo/algo/service/image/ImageService.java
@@ -11,6 +11,7 @@ import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.UUID;
 
 @Service
@@ -25,8 +26,22 @@ public class ImageService {
     @Value("${cloud.aws.region.static}")
     private String region;
 
+    private static final List<String> ALLOWED_EXTENSIONS = List.of("jpg", "jpeg", "png", "gif");
+
+
     public String uploadImage(MultipartFile file) {
-        String fileName = UUID.randomUUID() + "-" + file.getOriginalFilename();
+        String originalName = file.getOriginalFilename();
+        if (originalName == null || !originalName.contains(".")) {
+            throw new CustomException(ErrorCode.INVALID_FILE_TYPE);
+        }
+
+        String ext = originalName.substring(originalName.lastIndexOf(".") + 1).toLowerCase();
+
+        if(!ALLOWED_EXTENSIONS.contains(ext)) {
+            throw new CustomException(ErrorCode.INVALID_FILE_TYPE);
+        }
+
+        String fileName = System.currentTimeMillis() + "-" + UUID.randomUUID() + ext;
 
         try {
             PutObjectRequest putObjectRequest = PutObjectRequest.builder()

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -24,6 +24,11 @@ spring:
       port: 6379
       host: ${REDIS_HOST}
 
+  servlet:
+    multipart:
+      max-file-size: 20MB
+      max-request-size: 20MB
+
 cloud:
   aws:
     credentials:


### PR DESCRIPTION
## 💻 작업 내용
- 이미지 업로드 시 500 에러 발생 원인 해결
  - `MaxUploadSizeExceededException` 발생 → 업로드 용량 제한 상향
- 이미지 파일명 규칙 개선
  - `System.currentTimeMillis() + "-" + UUID + 확장자` 형식 적용
  - 원본 파일명 제거 → URL 길이 초과 문제 방지

## 📌 변경 사항
- `application.yml`: 업로드 제한값 상향 (`max-file-size`, `max-request-size`)
- `ImageService.uploadImage`: 파일명 생성 로직 및 확장자 검증 추가
- `ErrorCode.INVALID_FILE_TYPE` 추가

## 🔗 관련 이슈
<!-- 예: close #123 -->

## 📝 기타
