### PR TITLE
[REFACTOR] 카카오 로그인 redirect uri 환경별 처리

### DIFF
--- a/src/main/java/com/teamalgo/algo/controller/AuthController.java
+++ b/src/main/java/com/teamalgo/algo/controller/AuthController.java
@@ -9,6 +9,7 @@ import com.teamalgo.algo.service.auth.GoogleOAuthService;
 import com.teamalgo.algo.service.auth.KakaoOAuthService;
 import com.teamalgo.algo.global.common.api.ApiResponse;
 import com.teamalgo.algo.global.common.code.SuccessCode;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
@@ -33,8 +34,12 @@ public class AuthController {
 
     // 카카오 로그인
     @PostMapping("/kakao-login")
-    public ResponseEntity<ApiResponse<TokenResponse>> kakaoLogin(@RequestBody LoginRequest loginRequest) {
-        TokenResponse response = kakaoOAuthService.authenticateUser(loginRequest.getToken());
+    public ResponseEntity<ApiResponse<TokenResponse>> kakaoLogin(
+            @RequestBody LoginRequest loginRequest,
+            HttpServletRequest request
+    ) {
+        String origin = request.getHeader("Origin");
+        TokenResponse response = kakaoOAuthService.authenticateUser(loginRequest.getToken(), origin);
         return ApiResponse.success(SuccessCode._OK, response);
     }
 

--- a/src/main/java/com/teamalgo/algo/global/common/code/ErrorCode.java
+++ b/src/main/java/com/teamalgo/algo/global/common/code/ErrorCode.java
@@ -29,7 +29,9 @@ public enum ErrorCode implements BaseCode {
     INVALID_STEPS(HttpStatus.BAD_REQUEST, "풀이 단계는 최소 1개 이상 필요합니다."),
     INVALID_CATEGORIES(HttpStatus.BAD_REQUEST, "카테고리는 최소 1개 이상 필요합니다."),
     INVALID_DETAIL(HttpStatus.BAD_REQUEST, "상세 설명은 비워둘 수 없습니다."),
-    INVALID_FILE_TYPE(HttpStatus.BAD_REQUEST, "허용되지 않은 이미지 형식입니다.");
+    INVALID_FILE_TYPE(HttpStatus.BAD_REQUEST, "허용되지 않은 이미지 형식입니다."),
+
+    INVALID_REDIRECT_URI(HttpStatus.BAD_REQUEST, "유효하지 않은 Redirect URI 입니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -38,6 +38,3 @@ cloud:
       static: ${AWS_REGION}
     s3:
       bucket: ${AWS_S3_BUCKET}
-
-kakao:
-  client-id: ${KAKAO_CLIENT_ID}


### PR DESCRIPTION
## 💻 작업 내용  
<!-- 이번 PR에서 작업한 내용을 간단하게 적어주세요 -->
- 카카오 OAuth 인증에서 redirect uri를 단일값에서 → Origin(local/server)별 처리로 개선

## 📌 변경 사항  
<!-- 코드 변경, 기능 추가/수정, 버그 수정 등 주요 변경 사항을 기술해주세요 -->
- KakaoOAuthService
  - redirect_uri를 Origin별로 선택하도록 로직 수정
  - 에러 로깅 및 CustomException 처리 강화

## 🔗 관련 이슈  
<!-- 연결된 이슈 번호를 적어주세요 (ex. #123) -->

## 📝 기타  
<!-- 특이사항, 참고할 점, 리뷰어에게 전달할 내용 등이 있다면 작성해주세요 -->
