### PR TITLE
[FIX] 레코드 수정 시 url 변경 허용

### DIFF
--- a/src/main/java/com/teamalgo/algo/domain/record/Record.java
+++ b/src/main/java/com/teamalgo/algo/domain/record/Record.java
@@ -110,4 +110,8 @@ public class Record extends BaseEntity {
     }
 
     public void updateStatus(String status) { this.status = status; }
+
+    public void updateProblem(Problem newProblem) { this.problem = newProblem;}
+
+
 }

--- a/src/main/java/com/teamalgo/algo/dto/request/RecordUpdateRequest.java
+++ b/src/main/java/com/teamalgo/algo/dto/request/RecordUpdateRequest.java
@@ -19,6 +19,8 @@ import java.util.List;
 @Schema(description = "레코드 수정 요청 DTO (전체 교체)")
 public class RecordUpdateRequest {
 
+    private String problemUrl;
+
     @Schema(description = "사용자 커스텀 제목")
     private String customTitle;
 

--- a/src/main/java/com/teamalgo/algo/global/common/code/ErrorCode.java
+++ b/src/main/java/com/teamalgo/algo/global/common/code/ErrorCode.java
@@ -24,6 +24,7 @@ public enum ErrorCode implements BaseCode {
     MISSING_TITLE(HttpStatus.BAD_REQUEST, "제목을 입력해주세요."),
     // 레코드 발행 시 에러
     INVALID_STATUS(HttpStatus.BAD_REQUEST, "Status 값은 success 또는 fail 이어야 합니다."),
+    INVALID_VERDICT(HttpStatus.BAD_REQUEST, "Verdict 값은 success 또는 fail 이어야 합니다."),
     INVALID_DIFFICULTY(HttpStatus.BAD_REQUEST, "난이도는 1~5 사이여야 합니다."),
     INVALID_CODES(HttpStatus.BAD_REQUEST, "코드는 최소 1개 이상 필요합니다."),
     INVALID_STEPS(HttpStatus.BAD_REQUEST, "풀이 단계는 최소 1개 이상 필요합니다."),

--- a/src/main/java/com/teamalgo/algo/service/record/RecordService.java
+++ b/src/main/java/com/teamalgo/algo/service/record/RecordService.java
@@ -127,6 +127,10 @@ public class RecordService {
         if (req.getCodes() != null) {
             AtomicInteger order = new AtomicInteger(0);
             for (RecordCodeDTO dto : req.getCodes()) {
+                if (dto.getVerdict() == null ||
+                        (!dto.getVerdict().equals("success") && !dto.getVerdict().equals("fail"))) {
+                    throw new CustomException(ErrorCode.INVALID_VERDICT);
+                }
                 RecordCode entity = dto.toEntity(record);
                 entity.update(dto.getLanguage(), dto.getCode(), dto.getVerdict(), order.getAndIncrement());
                 record.getCodes().add(entity);
@@ -408,6 +412,10 @@ public class RecordService {
             recordRepository.flush();
             AtomicInteger order = new AtomicInteger(0);
             for (RecordCodeDTO dto : req.getCodes()) {
+                if (dto.getVerdict() == null ||
+                        (!dto.getVerdict().equals("success") && !dto.getVerdict().equals("fail"))) {
+                    throw new CustomException(ErrorCode.INVALID_VERDICT);
+                }
                 RecordCode entity = dto.toEntity(record);
                 entity.update(dto.getLanguage(), dto.getCode(), dto.getVerdict(), order.getAndIncrement());
                 record.getCodes().add(entity);


### PR DESCRIPTION
## 💻 작업 내용  
<!-- 이번 PR에서 작업한 내용을 간단하게 적어주세요 -->

- RecordUpdateRequest DTO에 problemUrl 필드 추가 → 수정 시 URL 입력 가능
- RecordService.updateRecord 로직 수정
 > problemUrl 값이 존재하면 새로운 Problem 조회/생성 후 record.updateProblem() 으로 교체, url 값이 없거나 공백일 경우 기존 Problem 유지 (URL 제거 불가)
- Record 엔티티에 updateProblem(Problem newProblem) 메서드 추가 → 연결된 Problem 교체 가능하도록 확장
- URL 변경 시 ProblemService.fetchProblemInfo + ProblemSourceDetector 로 source/title 자동 처리
*title을 지원하지 않는 사이트의 url로 변경하는 경우, 해당 url의 title이 problem 엔터티에 존재하지 않으면 customTitle을 무조건 새로 작성해야 함. (new Problem을 생성해야 되기에)
- 코드에 verdict 값 success/fail로 검증 로직 추가