### PR TITLE
[FIX] 카테고리 통계 draft 미반영 및 내기록 필터링 추가

### DIFF
--- a/src/main/java/com/teamalgo/algo/controller/MyRecordController.java
+++ b/src/main/java/com/teamalgo/algo/controller/MyRecordController.java
@@ -25,11 +25,16 @@ public class MyRecordController {
     public ResponseEntity<ApiResponse<RecordListResponse>> getMyRecords(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestParam(defaultValue = "1") int page,
-            @RequestParam(defaultValue = "10") int size
+            @RequestParam(defaultValue = "10") int size,
+            @RequestParam(required = false) String category
     ) {
         User user = userDetails.getUser();
         int pageIndex = (page > 0) ? page - 1 : 0;
-        Page<com.teamalgo.algo.domain.record.Record> records = recordService.getRecordsByUser(user, PageRequest.of(pageIndex, size));
+
+        Page<com.teamalgo.algo.domain.record.Record>  records = (category == null || category.isBlank())
+                ? recordService.getUserRecords(user.getId(), PageRequest.of(pageIndex, size))
+                : recordService.getUserRecords(user.getId(), PageRequest.of(pageIndex, size), category);
+
         RecordListResponse response = recordService.createRecordListResponse(records);
         return ApiResponse.success(SuccessCode._OK, response);
     }

--- a/src/main/java/com/teamalgo/algo/repository/RecordCategoryRepository.java
+++ b/src/main/java/com/teamalgo/algo/repository/RecordCategoryRepository.java
@@ -18,6 +18,7 @@ public interface RecordCategoryRepository extends JpaRepository<RecordCategory, 
     JOIN rc.record r
     JOIN rc.category c
     WHERE r.user = :user
+        AND r.isDraft = false
     GROUP BY c.name
     ORDER BY solvedCount DESC, lastSolvedDate DESC
 """)
@@ -27,6 +28,7 @@ public interface RecordCategoryRepository extends JpaRepository<RecordCategory, 
             "FROM RecordCategory rc " +
             "JOIN rc.category c " +
             "WHERE rc.record.user.id = :userId " +
+            "AND rc.record.isDraft = false " +
             "GROUP BY c.slug, c.name")
     List<CategoryStatsResponse> findCategoryCountsByUserId(@Param("userId") Long userId);
 

--- a/src/main/java/com/teamalgo/algo/repository/RecordRepository.java
+++ b/src/main/java/com/teamalgo/algo/repository/RecordRepository.java
@@ -47,4 +47,18 @@ public interface RecordRepository extends JpaRepository<Record, Long>, JpaSpecif
             @Param("endDate") LocalDateTime endDate,
             Pageable pageable
     );
+
+    @Query("""
+        SELECT r FROM Record r
+        JOIN r.recordCategories rc
+        JOIN rc.category c
+        WHERE r.user.id = :userId
+        AND r.isDraft = false
+        AND c.name = :categoryName
+    """)
+    Page<Record> findByUserIdAndIsDraftFalseAndCategoryName(
+            @Param("userId") Long userId,
+            @Param("categoryName") String categoryName,
+            Pageable pageable
+    );
 }

--- a/src/main/java/com/teamalgo/algo/service/record/RecordService.java
+++ b/src/main/java/com/teamalgo/algo/service/record/RecordService.java
@@ -305,8 +305,12 @@ public class RecordService {
     }
 
     //  내 레코드 목록
-    public Page<com.teamalgo.algo.domain.record.Record> getRecordsByUser(User user, Pageable pageable) {
-        return recordRepository.findByUserIdAndIsDraftFalse(user.getId(), pageable);
+    public Page<com.teamalgo.algo.domain.record.Record>  getUserRecords(Long userId, Pageable pageable) {
+        return recordRepository.findByUserIdAndIsDraftFalse(userId, pageable);
+    }
+
+    public Page<com.teamalgo.algo.domain.record.Record> getUserRecords(Long userId, Pageable pageable, String category) {
+        return recordRepository.findByUserIdAndIsDraftFalseAndCategoryName(userId, category, pageable);
     }
 
     // Draft 목록
@@ -464,7 +468,7 @@ public class RecordService {
         // Categories
         if (req.getCategories() != null) {
             record.getRecordCategories().clear();
-            recordRepository.flush();
+
             for (String catName : req.getCategories()) {
                 Category category = categoryRepository.findByName(catName)
                         .orElseGet(() -> categoryRepository.save(


### PR DESCRIPTION
## 💻 작업 내용  
<!-- 이번 PR에서 작업한 내용을 간단하게 적어주세요 -->

- /api/users/me/categories 에서 draft 기록의 카테고리까지 반영되던 부분 수정
- 내 기록 목록 조회 시 category 파라미터로 필터링 기능 추가 (파라미터 안 보낼 경우에는 전체 조회)