### PR TITLE
[FEAT] 문제 유형 조회 API 추가 & categoryIds 기반 매핑으로 변

### DIFF
--- a/src/main/java/com/teamalgo/algo/controller/CategoryController.java
+++ b/src/main/java/com/teamalgo/algo/controller/CategoryController.java
@@ -1,0 +1,28 @@
+package com.teamalgo.algo.controller;
+
+import com.teamalgo.algo.dto.CategoryDTO;
+import com.teamalgo.algo.global.common.api.ApiResponse;
+import com.teamalgo.algo.global.common.code.SuccessCode;
+import com.teamalgo.algo.service.record.CategoryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/records/categories")
+public class CategoryController {
+
+    private final CategoryService categoryService;
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<CategoryDTO>>> getCategories() {
+        List<CategoryDTO> response = categoryService.getCategories();
+        return ApiResponse.success(SuccessCode._OK, response);
+    }
+
+}

--- a/src/main/java/com/teamalgo/algo/domain/category/Category.java
+++ b/src/main/java/com/teamalgo/algo/domain/category/Category.java
@@ -18,6 +18,4 @@ public class Category {
     @Column(nullable = false, unique = true)
     private String name;
 
-    @Column(nullable = false, unique = true)
-    private String slug;
 }

--- a/src/main/java/com/teamalgo/algo/dto/CategoryDTO.java
+++ b/src/main/java/com/teamalgo/algo/dto/CategoryDTO.java
@@ -1,0 +1,13 @@
+package com.teamalgo.algo.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CategoryDTO {
+
+    private Long id;
+    private String name;
+
+}

--- a/src/main/java/com/teamalgo/algo/dto/request/RecordCreateRequest.java
+++ b/src/main/java/com/teamalgo/algo/dto/request/RecordCreateRequest.java
@@ -24,7 +24,7 @@ public class RecordCreateRequest {
     @Size(max = 200, message = "Title should not exceed 200 characters")
     private String customTitle;
 
-    private List<String> categories;
+    private List<Long> categoryIds;
     private String status;
     private Integer difficulty;
     private String detail;

--- a/src/main/java/com/teamalgo/algo/dto/request/RecordUpdateRequest.java
+++ b/src/main/java/com/teamalgo/algo/dto/request/RecordUpdateRequest.java
@@ -40,7 +40,7 @@ public class RecordUpdateRequest {
     private List<RecordLinkDTO> links;
 
     @Schema(description = "카테고리 목록", example = "[\"DP\", \"Graph\"]")
-    private List<String> categories;
+    private List<Long> categoryIds;
 
     private String status;
     private Integer difficulty;

--- a/src/main/java/com/teamalgo/algo/service/record/CategoryService.java
+++ b/src/main/java/com/teamalgo/algo/service/record/CategoryService.java
@@ -1,0 +1,23 @@
+package com.teamalgo.algo.service.record;
+
+import com.teamalgo.algo.domain.category.Category;
+import com.teamalgo.algo.dto.CategoryDTO;
+import com.teamalgo.algo.repository.CategoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class CategoryService {
+
+    private final CategoryRepository categoryRepository;
+
+    public List<CategoryDTO> getCategories () {
+        return categoryRepository.findAll().stream()
+                .map(category -> new CategoryDTO(category.getId(), category.getName()))
+                .toList();
+    }
+
+}


### PR DESCRIPTION
## 💻 작업 내용
- `GET /api/categories` API 구현
- RecordCreateRequest, RecordUpdateRequest에서 `categories`(문자열) → `categoryIds`(Long 리스트)로 변경
- RecordService 리팩터링
  - categoryIds로 검증 후 RecordCategory 매핑
  - DB에 없는 categoryId가 들어올 경우 예외 처리

## 📌 변경 사항
- DTO 필드명 변경: `categories` → `categoryIds`
- 서비스 계층에서 CategoryRepository를 이용한 id 검증 로직 추가
- DB: 기존 slug 컬럼 제거 (관련 코드 수정)

## 🔗 관련 이슈
- closes #이슈번호 (있다면 기재)

## 📝 기타
- 프론트엔드에서 category 선택 시 id 기반으로 요청 필요
- DB 마이그레이션 : `ALTER TABLE category DROP COLUMN slug;`