### PR TITLE
[FIX] slug 필드 삭제에 다른 JPQL & DTO 수정

### DIFF
--- a/src/main/java/com/teamalgo/algo/dto/response/CategoryStatsResponse.java
+++ b/src/main/java/com/teamalgo/algo/dto/response/CategoryStatsResponse.java
@@ -7,13 +7,11 @@ import lombok.Getter;
 @AllArgsConstructor
 public class CategoryStatsResponse {
 
-    private String slug;
     private String name;
     private Long count;
     private Double ratio;
 
-    public CategoryStatsResponse(String slug, String name, Long count) {
-        this.slug = slug;
+    public CategoryStatsResponse(String name, Long count) {
         this.name = name;
         this.count = count;
         this.ratio = 0.0;

--- a/src/main/java/com/teamalgo/algo/repository/RecordCategoryRepository.java
+++ b/src/main/java/com/teamalgo/algo/repository/RecordCategoryRepository.java
@@ -24,12 +24,12 @@ public interface RecordCategoryRepository extends JpaRepository<RecordCategory, 
 """)
     List<Object[]> findMostSolvedByUser(@Param("user") User user, Pageable pageable);
 
-    @Query("SELECT new com.teamalgo.algo.dto.response.CategoryStatsResponse(c.slug, c.name, COUNT(rc)) " +
+    @Query("SELECT new com.teamalgo.algo.dto.response.CategoryStatsResponse(c.name, COUNT(rc)) " +
             "FROM RecordCategory rc " +
             "JOIN rc.category c " +
             "WHERE rc.record.user.id = :userId " +
             "AND rc.record.isDraft = false " +
-            "GROUP BY c.slug, c.name")
+            "GROUP BY c.name")
     List<CategoryStatsResponse> findCategoryCountsByUserId(@Param("userId") Long userId);
 
 }

--- a/src/main/java/com/teamalgo/algo/service/stats/CategoryStatsService.java
+++ b/src/main/java/com/teamalgo/algo/service/stats/CategoryStatsService.java
@@ -22,7 +22,6 @@ public class CategoryStatsService {
 
         return results.stream()
                 .map(r -> new CategoryStatsResponse(
-                        r.getSlug(),
                         r.getName(),
                         r.getCount(),
                         Math.round(((double) r.getCount() / total) * 1000) / 10.0


### PR DESCRIPTION
## 💻 작업 내용  
- RecordCategoryRepository JPQL 쿼리에서 `c.slug` 제거
- CategoryStatsResponse DTO 생성자에서 slug 매개변수 삭제
- 불필요한 slug 참조 제거로 애플리케이션 구동 시 Bean 생성 오류 해결