### PR TITLE
fix: 복습 추천 조회 시 draft 노출 문제 수정

### DIFF
--- a/src/main/java/com/teamalgo/algo/repository/RecordRepository.java
+++ b/src/main/java/com/teamalgo/algo/repository/RecordRepository.java
@@ -66,4 +66,18 @@ public interface RecordRepository extends JpaRepository<Record, Long>, JpaSpecif
             @Param("categoryName") String categoryName,
             Pageable pageable
     );
+
+    @Query("""
+        SELECT r
+        FROM Record r
+        WHERE r.user.id = :userId
+          AND r.isDraft = false
+          AND NOT EXISTS (
+              SELECT 1 FROM ReviewLog rl
+              WHERE rl.user.id = :userId
+                AND rl.record.id = r.id
+          )
+    """)
+    List<Record> findUnreviewedRecords(@Param("userId") Long userId);
+
 }

--- a/src/main/java/com/teamalgo/algo/service/record/ReviewService.java
+++ b/src/main/java/com/teamalgo/algo/service/record/ReviewService.java
@@ -45,11 +45,9 @@ public class ReviewService {
 
     // 추천 복습 문제 조회
     public List<RecordDTO> getRecommendedReviews(Long userId) {
-        List<Record> records = recordRepository.findByUserId(userId);
+        List<Record> records = recordRepository.findUnreviewedRecords(userId);
 
         return records.stream()
-                // 이미 복습한 건 제외
-                .filter(record -> !reviewLogRepository.existsByUserIdAndRecordId(userId, record.getId()))
                 .map(record -> {
                     int difficulty = record.getDifficulty() != null ? record.getDifficulty() : 1;
                     int complexity = calculateComplexityScore(record);


### PR DESCRIPTION
## 💻 작업 내용  
- 임시저장한 기록이 복습 추천 문제로 뜨는 오류 해결

## 📌 변경 사항  
<!-- 코드 변경, 기능 추가/수정, 버그 수정 등 주요 변경 사항을 기술해주세요 -->
- RecordRepository에 `findUnreviewedRecords` 메소드 추가
  - draft=false 조건
  - ReviewLog 없는 기록만 조회
- ReviewService에서 filter 제거 후 Repository 활용

## 🔗 관련 이슈  
<!-- 연결된 이슈 번호를 적어주세요 (ex. #123) -->

## 📝 기타  
<!-- 특이사항, 참고할 점, 리뷰어에게 전달할 내용 등이 있다면 작성해주세요 -->
