### PR TITLE
[FEAT] 북마크/내기록/아이디어 조회 시 categoryId 기반 필터링 적용

### DIFF
--- a/src/main/java/com/teamalgo/algo/controller/BookmarkController.java
+++ b/src/main/java/com/teamalgo/algo/controller/BookmarkController.java
@@ -59,15 +59,14 @@ public class BookmarkController {
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestParam(defaultValue = "1") int page,
             @RequestParam(defaultValue = "10") int size,
-            @RequestParam(required = false) String category,
+            @RequestParam(required = false) Long categoryId,
             @RequestParam(defaultValue = "all") String ownerType // mine, others, all
     ) {
         User user = userDetails.getUser();
-
         int pageIndex = (page > 0) ? page - 1 : 0;
         Pageable pageable = PageRequest.of(pageIndex, size);
 
-        var bookmarks = bookmarkService.getBookmarkedRecords(user, pageable, category, ownerType);
+        var bookmarks = bookmarkService.getBookmarkedRecords(user, pageable, categoryId, ownerType);
 
         BookmarkListResponse response = BookmarkListResponse.fromPage(bookmarks);
         return ApiResponse.success(SuccessCode._OK, response);

--- a/src/main/java/com/teamalgo/algo/controller/CoreIdeaController.java
+++ b/src/main/java/com/teamalgo/algo/controller/CoreIdeaController.java
@@ -31,19 +31,16 @@ public class CoreIdeaController {
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestParam(defaultValue = "1") int page,
             @RequestParam(defaultValue = "10") int size,
-            @RequestParam(required = false) String category
+            @RequestParam(required = false) Long categoryId
     ) {
         User user = userService.findById(userDetails.getUser().getId())
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
         int pageIndex = (page > 0) ? page - 1 : 0;
 
-        Page<CoreIdeaDTO> ideas;
-        if (category == null || category.isBlank()) {
-            ideas = coreIdeaService.getUserIdeas(user.getId(), PageRequest.of(pageIndex, size));
-        } else {
-            ideas = coreIdeaService.getUserIdeas(user.getId(), PageRequest.of(pageIndex, size), category);
-        }
+        Page<CoreIdeaDTO> ideas = (categoryId == null)
+                ? coreIdeaService.getUserIdeas(user.getId(), PageRequest.of(pageIndex, size))
+                : coreIdeaService.getUserIdeas(user.getId(), PageRequest.of(pageIndex, size), categoryId);
 
         CoreIdeaListResponse response = CoreIdeaListResponse.fromPage(ideas);
         return ApiResponse.success(SuccessCode._OK, response);

--- a/src/main/java/com/teamalgo/algo/controller/MyRecordController.java
+++ b/src/main/java/com/teamalgo/algo/controller/MyRecordController.java
@@ -26,14 +26,14 @@ public class MyRecordController {
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestParam(defaultValue = "1") int page,
             @RequestParam(defaultValue = "10") int size,
-            @RequestParam(required = false) String category
+            @RequestParam(required = false) Long categoryId
     ) {
         User user = userDetails.getUser();
         int pageIndex = (page > 0) ? page - 1 : 0;
 
-        Page<com.teamalgo.algo.domain.record.Record>  records = (category == null || category.isBlank())
+        Page<com.teamalgo.algo.domain.record.Record>  records = (categoryId == null)
                 ? recordService.getUserRecords(user.getId(), PageRequest.of(pageIndex, size))
-                : recordService.getUserRecords(user.getId(), PageRequest.of(pageIndex, size), category);
+                : recordService.getUserRecords(user.getId(), PageRequest.of(pageIndex, size), categoryId);
 
         RecordListResponse response = recordService.createRecordListResponse(records);
         return ApiResponse.success(SuccessCode._OK, response);

--- a/src/main/java/com/teamalgo/algo/repository/BookmarkRepository.java
+++ b/src/main/java/com/teamalgo/algo/repository/BookmarkRepository.java
@@ -21,8 +21,8 @@ public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
     Optional<Bookmark> findByUserAndRecordAndRecordIsDraftFalse(User user, Record record);
 
     // 카테고리별 북마크 목록
-    Page<Bookmark> findByUserAndRecordIsDraftFalseAndRecord_RecordCategories_Category_Name(
-            User user, String category, Pageable pageable);
+    Page<Bookmark> findByUserAndRecordIsDraftFalseAndRecord_RecordCategories_Category_Id(
+            User user, Long categoryId, Pageable pageable);
 
     // 전체 북마크 목록
     Page<Bookmark> findByUserAndRecordIsDraftFalse(User user, Pageable pageable);

--- a/src/main/java/com/teamalgo/algo/repository/RecordCoreIdeaRepository.java
+++ b/src/main/java/com/teamalgo/algo/repository/RecordCoreIdeaRepository.java
@@ -18,8 +18,8 @@ public interface RecordCoreIdeaRepository extends JpaRepository<RecordCoreIdea, 
 
 
     // 특정 카테고리 + draft 제외
-    Page<RecordCoreIdea> findByRecordUserIdAndRecordIsDraftFalseAndRecord_RecordCategories_Category_NameAndContentIsNotNullAndContentNot(
-            Long userId, String category, String empty, Pageable pageable);
+    Page<RecordCoreIdea> findByRecordUserIdAndRecordIsDraftFalseAndRecord_RecordCategories_Category_IdAndContentIsNotNullAndContentNot(
+            Long userId, Long categoryId, String empty, Pageable pageable);
 
 
     // 최신순 + draft 제외

--- a/src/main/java/com/teamalgo/algo/repository/RecordRepository.java
+++ b/src/main/java/com/teamalgo/algo/repository/RecordRepository.java
@@ -59,11 +59,11 @@ public interface RecordRepository extends JpaRepository<Record, Long>, JpaSpecif
         JOIN rc.category c
         WHERE r.user.id = :userId
         AND r.isDraft = false
-        AND c.name = :categoryName
+        AND c.id = :categoryId
     """)
-    Page<Record> findByUserIdAndIsDraftFalseAndCategoryName(
+    Page<Record> findByUserIdAndIsDraftFalseAndCategoryId(
             @Param("userId") Long userId,
-            @Param("categoryName") String categoryName,
+            @Param("categoryId") Long categoryId,
             Pageable pageable
     );
 

--- a/src/main/java/com/teamalgo/algo/service/record/BookmarkService.java
+++ b/src/main/java/com/teamalgo/algo/service/record/BookmarkService.java
@@ -56,15 +56,15 @@ public class BookmarkService {
     }
 
     // 북마크한 레코드 목록 조회 (category, 작성자 필터링)
-    public Page<RecordDTO> getBookmarkedRecords(User user, Pageable pageable, String category, String ownerType) {
+    public Page<RecordDTO> getBookmarkedRecords(User user, Pageable pageable,  Long categoryId, String ownerType) {
         Page<Record> records;
 
-        if (category == null || category.isBlank()) {
+        if (categoryId == null) {
             records = bookmarkRepository.findByUserAndRecordIsDraftFalse(user, pageable)
                     .map(Bookmark::getRecord);
         } else {
-            records = bookmarkRepository.findByUserAndRecordIsDraftFalseAndRecord_RecordCategories_Category_Name(
-                            user, category, pageable)
+            records = bookmarkRepository.findByUserAndRecordIsDraftFalseAndRecord_RecordCategories_Category_Id(
+                            user, categoryId, pageable)
                     .map(Bookmark::getRecord);
         }
 

--- a/src/main/java/com/teamalgo/algo/service/record/CoreIdeaService.java
+++ b/src/main/java/com/teamalgo/algo/service/record/CoreIdeaService.java
@@ -25,14 +25,14 @@ public class CoreIdeaService {
     }
 
     // 핵심 아이디어 목록 조회 (카테고리 선택 O)
-    public Page<CoreIdeaDTO> getUserIdeas(Long userId, Pageable pageable, String category) {
-        if (category == null || category.isBlank()) {
+    public Page<CoreIdeaDTO> getUserIdeas(Long userId, Pageable pageable, Long categoryId) {
+        if (categoryId == null) {
             return getUserIdeas(userId, pageable);
         }
 
         return recordCoreIdeaRepository
-                .findByRecordUserIdAndRecordIsDraftFalseAndRecord_RecordCategories_Category_NameAndContentIsNotNullAndContentNot(
-                        userId, category, "", pageable
+                .findByRecordUserIdAndRecordIsDraftFalseAndRecord_RecordCategories_Category_IdAndContentIsNotNullAndContentNot(
+                        userId, categoryId, "", pageable
                 )
                 .map(CoreIdeaDTO::fromEntity);
     }

--- a/src/main/java/com/teamalgo/algo/service/record/RecordService.java
+++ b/src/main/java/com/teamalgo/algo/service/record/RecordService.java
@@ -291,8 +291,8 @@ public class RecordService {
         return recordRepository.findByUserIdAndIsDraftFalse(userId, pageable);
     }
 
-    public Page<com.teamalgo.algo.domain.record.Record> getUserRecords(Long userId, Pageable pageable, String category) {
-        return recordRepository.findByUserIdAndIsDraftFalseAndCategoryName(userId, category, pageable);
+    public Page<com.teamalgo.algo.domain.record.Record> getUserRecords(Long userId, Pageable pageable, Long categoryId) {
+        return recordRepository.findByUserIdAndIsDraftFalseAndCategoryId(userId, categoryId, pageable);
     }
 
     // Draft 목록


### PR DESCRIPTION
## 💻 작업 내용
- 유형을 드롭다운 형태로 불러오는 북마크/내기록/핵심아이디어의 경우, categoryId 기준으로 조회되게끔 수정