### PR TITLE
[FIX] 임시저장한 기록 발행 시 createdAt이 발행일이 되도록 수정

### DIFF
--- a/src/main/java/com/teamalgo/algo/domain/record/Record.java
+++ b/src/main/java/com/teamalgo/algo/domain/record/Record.java
@@ -11,6 +11,7 @@ import lombok.*;
 import org.hibernate.annotations.Fetch;
 import org.hibernate.annotations.FetchMode;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -113,5 +114,8 @@ public class Record extends BaseEntity {
 
     public void updateProblem(Problem newProblem) { this.problem = newProblem;}
 
+    public void publish() {
+        this.setCreatedAt(LocalDateTime.now());
+    }
 
 }

--- a/src/main/java/com/teamalgo/algo/global/entity/BaseEntity.java
+++ b/src/main/java/com/teamalgo/algo/global/entity/BaseEntity.java
@@ -16,7 +16,7 @@ import java.time.LocalDateTime;
 public abstract class BaseEntity {
 
     @CreatedDate
-    @Column(updatable = false, nullable = false,
+    @Column(nullable = false,
             columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP")
     private LocalDateTime createdAt;
 
@@ -24,4 +24,8 @@ public abstract class BaseEntity {
     @Column(nullable = false,
             columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP")
     private LocalDateTime updatedAt;
+
+    protected void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
 }

--- a/src/main/java/com/teamalgo/algo/service/record/RecordService.java
+++ b/src/main/java/com/teamalgo/algo/service/record/RecordService.java
@@ -448,6 +448,7 @@ public class RecordService {
         if (prevDraft && !record.isDraft()) {
             boolean isSuccess = "success".equals(record.getStatus());
             statsService.increaseStats(user, isSuccess);
+            record.publish();
         }
 
         return record;


### PR DESCRIPTION
## 💻 작업 내용  
<!-- 이번 PR에서 작업한 내용을 간단하게 적어주세요 -->
- `Record` 엔티티에 `publish()` 메서드 추가
- `createdAt`을 발행 시점(`LocalDateTime.now()`)으로 세팅