### PR TITLE
[FIX] 기록 수정 시 카테고리 중복 삽입으로 인한 unique 제약 오류 해결

### DIFF
--- a/src/main/java/com/teamalgo/algo/service/record/RecordService.java
+++ b/src/main/java/com/teamalgo/algo/service/record/RecordService.java
@@ -444,6 +444,7 @@ public class RecordService {
         // Categories
         if (req.getCategoryIds() != null) {
             record.getRecordCategories().clear();
+            recordRepository.flush();
             setCategoriesForRecord(record, req.getCategoryIds());
         }
 


### PR DESCRIPTION
## 💻 작업 내용  
- `updateRecord` 로직 수정
  - 기존 카테고리 관계를 `clear()` 후 `flush()`로 즉시 삭제 반영
  - 새로운 카테고리 매핑 추가 시 unique 제약 조건 위반이 발생하지 않도록 처리