### PR TITLE
[FEAT] 코드 및 풀이 갯수 제한 & 최신순 설정

### DIFF
--- a/src/main/java/com/teamalgo/algo/dto/request/RecordCreateRequest.java
+++ b/src/main/java/com/teamalgo/algo/dto/request/RecordCreateRequest.java
@@ -29,7 +29,9 @@ public class RecordCreateRequest {
     private Integer difficulty;
     private String detail;
 
+    @Size(max = 3, message = "코드는 최대 3개까지만 등록 가능합니다.")
     private List<@Valid RecordCodeDTO> codes;
+    @Size(max = 10, message = "풀이 과정은 최대 10개까지만 등록 가능합니다.")
     private List<@Valid RecordStepDTO> steps;
 
     private List<RecordCoreIdeaDTO> ideas;

--- a/src/main/java/com/teamalgo/algo/service/record/CoreIdeaService.java
+++ b/src/main/java/com/teamalgo/algo/service/record/CoreIdeaService.java
@@ -4,6 +4,7 @@ import com.teamalgo.algo.dto.CoreIdeaDTO;
 import com.teamalgo.algo.repository.RecordCoreIdeaRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.data.domain.Page;
@@ -19,20 +20,31 @@ public class CoreIdeaService {
 
     // 핵심 아이디어 목록 조회 (카테고리 선택 X)
     public Page<CoreIdeaDTO> getUserIdeas(Long userId, Pageable pageable) {
+        Pageable sorted = PageRequest.of(
+                pageable.getPageNumber(),
+                pageable.getPageSize(),
+                Sort.by(Sort.Direction.DESC, "record.createdAt") // 최신순
+        );
         return recordCoreIdeaRepository
-                .findByRecordUserIdAndRecordIsDraftFalseAndContentIsNotNullAndContentNot(userId, "", pageable)
+                .findByRecordUserIdAndRecordIsDraftFalseAndContentIsNotNullAndContentNot(userId, "", sorted)
                 .map(CoreIdeaDTO::fromEntity);
     }
 
     // 핵심 아이디어 목록 조회 (카테고리 선택 O)
     public Page<CoreIdeaDTO> getUserIdeas(Long userId, Pageable pageable, Long categoryId) {
+        Pageable sorted = PageRequest.of(
+                pageable.getPageNumber(),
+                pageable.getPageSize(),
+                Sort.by(Sort.Direction.DESC, "record.createdAt") // 최신순
+        );
+
         if (categoryId == null) {
-            return getUserIdeas(userId, pageable);
+            return getUserIdeas(userId, sorted);
         }
 
         return recordCoreIdeaRepository
                 .findByRecordUserIdAndRecordIsDraftFalseAndRecord_RecordCategories_Category_IdAndContentIsNotNullAndContentNot(
-                        userId, categoryId, "", pageable
+                        userId, categoryId, "",sorted
                 )
                 .map(CoreIdeaDTO::fromEntity);
     }

--- a/src/main/java/com/teamalgo/algo/service/record/RecordService.java
+++ b/src/main/java/com/teamalgo/algo/service/record/RecordService.java
@@ -280,16 +280,22 @@ public class RecordService {
 
     //  내 레코드 목록
     public Page<com.teamalgo.algo.domain.record.Record>  getUserRecords(Long userId, Pageable pageable) {
-        return recordRepository.findByUserIdAndIsDraftFalse(userId, pageable);
+        Pageable sorted = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(),
+                Sort.by(Sort.Direction.DESC, "createdAt"));
+        return recordRepository.findByUserIdAndIsDraftFalse(userId, sorted);
     }
 
     public Page<com.teamalgo.algo.domain.record.Record> getUserRecords(Long userId, Pageable pageable, Long categoryId) {
-        return recordRepository.findByUserIdAndIsDraftFalseAndCategoryId(userId, categoryId, pageable);
+        Pageable sorted = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(),
+                Sort.by(Sort.Direction.DESC, "createdAt"));
+        return recordRepository.findByUserIdAndIsDraftFalseAndCategoryId(userId, categoryId, sorted);
     }
 
     // Draft 목록
     public Page<com.teamalgo.algo.domain.record.Record> getDraftsByUser(User user, Pageable pageable) {
-        return recordRepository.findByUserIdAndIsDraftTrue(user.getId(), pageable);
+        Pageable sorted = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(),
+                Sort.by(Sort.Direction.DESC, "createdAt"));
+        return recordRepository.findByUserIdAndIsDraftTrue(user.getId(), sorted);
     }
 
     // 레코드 수정


### PR DESCRIPTION
## 💻 작업 내용
- 코드(3개), 풀이과정(10개) 갯수 제한 로직 추가
- 북마크 목록 최신순 정렬 적용
- 핵심 아이디어 목록 최신순 정렬 적용
- 내 기록 / 임시저장 기록 최신순 정렬 적용